### PR TITLE
add support for "event commands"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ CPPFLAGS += -DSYSCONFDIR=\"$(SYSCONFDIR)\"
 CPPFLAGS += -DVERSION=\"${VERSION}\"
 CPPFLAGS += -DBLOCK_LIBEXEC=\"${BLOCK_LIBEXEC}\"
 CFLAGS += -Wall
+LDFLAGS += -lpthread
 
 OBJS := $(wildcard src/*.c *.c)
 OBJS := $(OBJS:.c=.o)

--- a/README.md
+++ b/README.md
@@ -2,23 +2,24 @@
 
 [![Build Status](https://travis-ci.org/vivien/i3blocks.svg?branch=master)](https://travis-ci.org/vivien/i3blocks)
 
-i3blocks is a highly flexible **status line** for the [i3](http://i3wm.org) 
-window manager. It handles *clicks*, *signals* and *language-agnostic* user 
+i3blocks is a highly flexible **status line** for the [i3](http://i3wm.org)
+window manager. It handles *clicks*, *signals* and *language-agnostic* user
 *scripts*.
 
-The content of each *block* (e.g. time, battery status, network state, ...) is 
-the output of a *command* provided by the user. Blocks are updated on *click*, 
-at a given *interval* of time or on a given *signal*, also specified by the 
+The content of each *block* (e.g. time, battery status, network state, ...) is
+the output of a *command* provided by the user. Blocks are updated on *click*,
+at a given *interval* of time or on a given *signal*, also specified by the
 user.
 
 It aims to respect the
-[i3bar protocol](http://i3wm.org/docs/i3bar-protocol.html), providing 
+[i3bar protocol](http://i3wm.org/docs/i3bar-protocol.html), providing
 customization such as text alignment, urgency, color, and more.
 
 - - -
 
-Here is an example of status line, showing the time updated every 5 seconds, 
-the volume updated only when i3blocks receives a SIGUSR1, and click events.
+Here is an example of status line, showing the time updated every 5 seconds,
+the volume updated only when i3blocks receives a SIGUSR1, click events,
+and the current song, updated everytime the wait command returns.
 
 ```` ini
 [volume]
@@ -34,10 +35,14 @@ interval=5
 command=echo button=$BLOCK_BUTTON x=$BLOCK_X y=$BLOCK_Y
 min_width=button=1 x=1366 y=768
 align=left
+
+[track]
+command=mpc current
+wait_command=mpc --wait current
 ````
 
-You can use your own scripts, or the 
-[ones](https://github.com/vivien/i3blocks/tree/master/scripts) provided with 
+You can use your own scripts, or the
+[ones](https://github.com/vivien/i3blocks/tree/master/scripts) provided with
 i3blocks. Feel free to contribute and improve them!
 
 The default config will look like this:
@@ -52,21 +57,21 @@ The scripts provided by default may use external tools:
 
 ## Documentation
 
-For more information about how it works, please refer to the 
+For more information about how it works, please refer to the
 [**manpage**](http://vivien.github.io/i3blocks).
 
 You can also take a look at the
-[i3bar protocol](http://i3wm.org/docs/i3bar-protocol.html) to see what 
+[i3bar protocol](http://i3wm.org/docs/i3bar-protocol.html) to see what
 possibilities it offers you.
 
-Take a look at the [wiki](https://github.com/vivien/i3blocks/wiki) for examples 
-of blocks and screenshots. If you want to share your ideas and status line, 
+Take a look at the [wiki](https://github.com/vivien/i3blocks/wiki) for examples
+of blocks and screenshots. If you want to share your ideas and status line,
 feel free to edit it!
 
 ## Installation
 
   * Download i3blocks and run `make install` within the source directory
-    * *Note that there's a [AUR](https://aur.archlinux.org/packages/i3blocks/) 
+    * *Note that there's a [AUR](https://aur.archlinux.org/packages/i3blocks/)
     package for Archlinux.*
   * set your `status_command` in a bar block of your ~/.i3/config file:
 

--- a/block.h
+++ b/block.h
@@ -19,6 +19,7 @@
 #ifndef _BLOCK_H
 #define _BLOCK_H
 
+#include <stdbool.h>
 #include "log.h"
 
 /* Keys part of the i3bar protocol */
@@ -46,10 +47,13 @@ struct block {
 
 	PROTOCOL_KEYS(MEMBER);
 	MEMBER(command, 1024, string);
+	MEMBER(wait_command, 1024, string);
 	unsigned interval;
 	unsigned signal;
+	bool waiting;
 	unsigned long last_update;
 	struct click click;
+	const struct block *config_block;
 
 #undef MEMBER
 };
@@ -70,5 +74,6 @@ struct status_line {
 	errorx("[%s] " msg, block->name, ##__VA_ARGS__)
 
 void block_update(struct block *);
+void block_update_wait(struct block *);
 
 #endif /* _BLOCK_H */

--- a/i3blocks.1
+++ b/i3blocks.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "I3BLOCKS" "1" "April 2014" "" ""
+.TH "I3BLOCKS" "1" "May 2014" "" ""
 .
 .SH "NAME"
 \fBi3blocks\fR \- define blocks for your i3bar status line
@@ -138,6 +138,10 @@ The following keys are specific to \fBi3blocks\fR\.
 .TP
 \fBcommand\fR
 The command executed by a shell, used to update the block\. The expected behavior is described below, in the \fICOMMAND\fR section\.
+.
+.TP
+\fBwait_command\fR
+An optional command that will sleep until an event\. The command output will be displayed only when the process is released\. If a normal \fBcommand\fR is also provided, it will also be called the first time to displayed instantly the output\. The format is the same as \fBcommand\fR\.
 .
 .TP
 \fBinterval\fR
@@ -291,6 +295,21 @@ The following block shows the usage of \fBsignal\fR with some i3(1) bindings whi
 command=echo \-n \'Volume: \'; amixer get Master | grep \-E \-o \'[0\-9][0\-9]?%\'
 signal=10
 # no interval, only check on SIGUSR1
+.
+.fi
+.
+.IP "" 0
+.
+.P
+This is an example of a wait command, allowing to update the current track played mpd(1) at the very time it is changed\. The \fBcommand\fR will be called at the first start to display the current music directly, and the \fBwait_command\fR is then called in loop, updating the current track each time it is released\.
+.
+.IP "" 4
+.
+.nf
+
+[track]
+command=mpc current
+wait_command=mpc \-\-wait current
 .
 .fi
 .

--- a/i3blocks.1.ronn
+++ b/i3blocks.1.ronn
@@ -13,7 +13,7 @@ It handles clicks, signals and user scripts.
 ## OPTIONS
 
   * `-c` <configfile>:
-    Specifies an alternate configuration file path. By default, i3blocks looks 
+    Specifies an alternate configuration file path. By default, i3blocks looks
     for configuration files in the following order:
 
         1. ~/.i3blocks.conf
@@ -88,6 +88,12 @@ The following keys are specific to **i3blocks**.
 	The command executed by a shell, used to update the block. The expected
     behavior is described below, in the [COMMAND][] section.
 
+  * `wait_command`:
+	An optional command that will sleep until an event. The command output
+	will be displayed only when the process is released. If a normal `command`
+	is also provided, it will also be called the first time to displayed
+	instantly the output. The format is the same as `command`.
+
   * `interval`:
 	The time in second to wait before updating the block. If 0, the block won't
     be updated again.
@@ -118,7 +124,7 @@ If the command line returns 0 or 33, the block is updated. Otherwise, it is
 considered a failure and the first line (if any) is still displayed. Note that
 stderr is ignored. A return code of 33 will set the `urgent` flag to true.
 
-For example, this script prints the battery percentage and sets the urgent flag 
+For example, this script prints the battery percentage and sets the urgent flag
 if it is below 10%:
 
     BAT=`acpi -b | grep -E -o '[0-9][0-9]?%'`
@@ -126,7 +132,7 @@ if it is below 10%:
     echo "BAT: $BAT"
     test ${BAT%?} -le 10 && exit 33 || exit 0
 
-When forking a block command, **i3blocks** will set the environment with some 
+When forking a block command, **i3blocks** will set the environment with some
 `BLOCK_*` variables. The following variables are always provided, with
 eventually an empty string as the value.
 
@@ -168,7 +174,7 @@ As an example, here is a close configuration to i3status(1) default settings:
     interval=5
     signal=10
 
-	[ipv6]
+    [ipv6]
 
     [free]
 
@@ -194,6 +200,16 @@ which adjust the volume, before issuing a `killall -USR1 i3blocks`:
     command=echo -n 'Volume: '; amixer get Master | grep -E -o '[0-9][0-9]?%'
     signal=10
     # no interval, only check on SIGUSR1
+
+This is an example of a wait command, allowing to update the current track
+played mpd(1) at the very time it is changed. The `command` will be called
+at the first start to display the current music directly, and the
+`wait_command` is then called in loop, updating the current track each
+time it is released.
+
+    [track]
+	command=mpc current
+	wait_command=mpc --wait current
 
 Here is an example of a very minimalist config, assuming you have a bunch of
 scripts under `~/bin/blocks/` with the same name as the blocks:
@@ -230,5 +246,5 @@ Written by Vivien Didelot <vivien.didelot@gmail.com>.
 Copyright (C) 2014 Vivien Didelot <vivien.didelot@gmail.com>
 License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>.
 
-This is free software: you are free to change and redistribute it. There is NO 
+This is free software: you are free to change and redistribute it. There is NO
 WARRANTY, to the extent permitted by law.

--- a/i3blocks.conf
+++ b/i3blocks.conf
@@ -37,6 +37,10 @@ min_width=CPU: 99.99%
 #command=$BLOCK_LIBEXEC/load_average
 #interval=10
 
+#[track]
+#command=mpc current
+#wait_command=mpc --wait current
+
 [battery]
 command=$BLOCK_LIBEXEC/battery BAT0
 interval=30

--- a/ini.c
+++ b/ini.c
@@ -97,6 +97,7 @@ parse_property(const char *line, struct block *block)
 
 	PROTOCOL_KEYS(PARSE);
 	PARSE(command, sizeof(block->command), _);
+	PARSE(wait_command, sizeof(block->wait_command), _);
 	PARSE_NUM(interval);
 	PARSE_NUM(signal);
 	/* TODO some better check for numbers and boolean */
@@ -157,6 +158,8 @@ parse_status_line(FILE *fp, struct status_line *status)
 
 			/* Init the block with default settings (if any) */
 			memcpy(block, &global, sizeof(struct block));
+
+			block->config_block = block;
 
 			if (parse_section(line, block->name, sizeof(block->name)))
 				return 1;

--- a/sched.h
+++ b/sched.h
@@ -19,6 +19,8 @@
 #ifndef _SCHED_H
 #define _SCHED_H
 
+#include "block.h"
+
 int sched_init(void);
 void sched_start(struct status_line *);
 


### PR DESCRIPTION
Some commands can sleep until an event is fired. This commit allows
i3blocks to support these kind of commands: the sleeping command is
started in a thread, and the status bar is updated instantly whenever
the subprocess exits.

The sleep command is then started again to wait for the next event.

When a wait command and a "normal" command aware both configured, the
"normal" command will be called on the very first time to get instantly
the status data.

This requires a dependency with POSIX threads library.

I also added examples of the `wait_command` configuration in the main
readme, the manpage, and as a commented block in the default configuration,
using mpc(1) with `--wait` option to get an "event" when the current song
played by mpd(1) changes.

My editor also removed automatically trailing whitespaces in some files,
I hope this is not a problem.
