### PR TITLE
man: update `BUGS` section

### DIFF
--- a/i3blocks.1
+++ b/i3blocks.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "I3BLOCKS" "1" "April 2014" "" ""
+.TH "I3BLOCKS" "1" "June 2014" "" ""
 .
 .SH "NAME"
 \fBi3blocks\fR \- define blocks for your i3bar status line
@@ -324,7 +324,12 @@ The development of i3blocks takes place on Github \fIhttps://github\.com/vivien/
 i3(1), i3bar(1), i3status(1)
 .
 .SH "BUGS"
-Currently the output is not JSON\-escaped\. This means that a script echoing chars such as \fB"\fR will break the status line\.
+.
+.SS "Reporting Bugs"
+Please report bugs on the issue tracker \fIhttps://github\.com/vivien/i3blocks/issues\fR\.
+.
+.SS "Known Bugs"
+None\.
 .
 .SH "AUTHOR"
 Written by Vivien Didelot \fIvivien\.didelot@gmail\.com\fR\.

--- a/i3blocks.1.ronn
+++ b/i3blocks.1.ronn
@@ -218,8 +218,13 @@ i3(1), i3bar(1), i3status(1)
 
 ## BUGS
 
-Currently the output is not JSON-escaped. This means that a script echoing
-chars such as `"` will break the status line.
+### Reporting Bugs
+
+Please report bugs on the [issue tracker](https://github.com/vivien/i3blocks/issues).
+
+### Known Bugs
+
+None.
 
 ## AUTHOR
 


### PR DESCRIPTION
Remove the JSON escape bug from the man page since it was fixed by #24.

Add a link to the issue tracker so the section is not left empty.
