### PR TITLE
cpu_usage: use consistent floating-point format.

### DIFF
--- a/scripts/cpu_usage
+++ b/scripts/cpu_usage
@@ -43,7 +43,8 @@ close(MPSTAT);
 $cpu_usage eq -1 and die 'Can\'t find CPU information';
 
 # Print short_text, full_text
-print "CPU: $cpu_usage%\n" x2;
+printf "CPU: %.2f%%\n", $cpu_usage;
+printf "CPU: %.2f%%\n", $cpu_usage;
 
 # Print color, if needed
 if ($cpu_usage >= $t_crit) {


### PR DESCRIPTION
If CPU usage is `1.00%`, this will be printed as `1.00%` and not `1%`. Thus display remains consistent.
