### PR TITLE
Fix a compilation error with -Werror=format-security

### DIFF
--- a/json.c
+++ b/json.c
@@ -72,11 +72,11 @@ print_prop(const char *key, const char *value, const int flags)
 
 	/* Print as-is (except strings which must be escaped) */
 	if (flags & PROP_STRING && flags & PROP_NUMBER && is_number(value))
-		fprintf(stdout, value);
+		fprintf(stdout, "%s", value);
 	else if (flags & PROP_STRING)
 		escape(value);
 	else
-		fprintf(stdout, value);
+		fprintf(stdout, "%s", value);
 }
 
 static void


### PR DESCRIPTION
Debian's dpkg-buildpackage seems to use -Werror=format-security.

This patch fixes a compilation error in json.c, and lets us build .deb packages for i3blocks.

Merci !
