### PR TITLE
Makefile: install the content of the contrib folder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ install: all
 	install -m 644 $(PROGRAM).1 $(DESTDIR)$(PREFIX)/share/man/man1
 	install -m 755 scripts/* $(DESTDIR)$(PREFIX)/libexec/$(PROGRAM)/
 	install -m 755 -d  $(DESTDIR)$(DOCDIR)/contrib
-	install -m 755 contrib/* $(DESTDIR)$(DOCDIR)/contrib
+	install -m 755 contrib/* $(DESTDIR)$(DOCDIR)/contrib/
 	chmod 644 $(DESTDIR)$(DOCDIR)/contrib/config
 
 uninstall:


### PR DESCRIPTION
Added DOCDIR (defaulting to $PREFIX/usr/share/doc/$PROGRAM), and
installed the contents of contrib/ to $DOCDIR/examples. Files are set to
755 except config, which is set to 644. This resolves #28.

Also fixed an issue with make uninstall where the manual page would not
get removed.
