### PR TITLE
Makefile: change the way VERSION is generated

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+RELEASE_VERSION = 1.2
+
 ifndef PREFIX
   PREFIX=/usr/local
 endif
@@ -14,9 +16,14 @@ endif
 ifndef DOCDIR
   DOCDIR=$(PREFIX)/share/doc/$(PROGRAM)
 endif
+ifndef VERSION
+  VERSION = "$(shell git describe --tags --always 2> /dev/null)"
+  ifeq ($(strip $(VERSION)),"")
+    VERSION = $(RELEASE_VERSION)
+  endif
+endif
 
 PROGRAM = i3blocks
-VERSION = "$(shell git describe --tags --always)"
 
 CPPFLAGS += -DSYSCONFDIR=\"$(SYSCONFDIR)\"
 CPPFLAGS += -DVERSION=\"${VERSION}\"


### PR DESCRIPTION
Issues:
- If we're building from a release tarball, VERSION is not set
- If we're building from another git repo (fork / packaging repo), and
  using our own tags, VERSION is set to something that doesn't not
  reflect the real version.

This patch fixes both issues, while keeping the default behavior when
building from the main git repo.
