### PR TITLE
Makefile: add a "release" target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,4 +75,8 @@ uninstall:
 	rm -rf $(DESTDIR)$(LIBEXECDIR)/$(PROGRAM)
 	rm -rf $(DESTDIR)$(DOCDIR)
 
+release: clean $(PROGRAM).1
+	tar -c --transform 's,^\./,./$(PROGRAM)-$(RELEASE_VERSION)/,' \
+		--exclude-vcs -f ../$(PROGRAM)-$(RELEASE_VERSION).tar.gz .
+
 .PHONY: all clean install uninstall


### PR DESCRIPTION
The release target in the Makefile will take care of generating the
manual page, and also create an i3blocks-version.tar.gz gzip'ed tarball.

The tarball will extract files to i3blocks-version/ directory.

I included the .1.ronn file as well, if you want to exclude it from the tarball, you can add 

```
--exclude=$(PROGRAM).1.ronn
```

to the tar command
