### PR TITLE
make dist target: gzip the tarball

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ uninstall:
 
 dist: clean man
 	( git ls-files * ; ls $(PROGRAM).1 ) | \
-	  tar -T - -c --transform 's,^,$(PROGRAM)-$(VERSION)/,' \
+	  tar -T - -c -z --transform 's,^,$(PROGRAM)-$(VERSION)/,' \
 	  -f $(PROGRAM)-$(VERSION).tar.gz
 
 .PHONY: all clean install uninstall


### PR DESCRIPTION
The archive was a .tar.gz, but was not actually gzip'ed. 

I didn't notice since I use "tar xf" to extract the files.
