### PR TITLE
scripts: (battery) reimplement multiple battery support

### DIFF
--- a/scripts/battery
+++ b/scripts/battery
@@ -21,12 +21,9 @@ my $status;
 my $percent;
 my $full_text;
 my $short_text;
-my $bat_number = 0;
 
-# read optional arg specifying battery number
-if ($#ARGV == 0) {
-	$bat_number = $ARGV[0];
-}
+# read optional variable specifying battery number
+my $bat_number = $ENV{BLOCK_INSTANCE} || 0;
 
 # read the first line of the "acpi" command output
 open (ACPI, "acpi -b | grep \"Battery $bat_number\" |") or die "Can't exec acpi: $!\n";


### PR DESCRIPTION
Added an optional arg for battery number (1 -> BAT1), defaults to 0.
