### PR TITLE
manpage: fix a small spelling error

### DIFF
--- a/i3blocks.1.ronn
+++ b/i3blocks.1.ronn
@@ -7,7 +7,7 @@ i3blocks(1) -- A flexible scheduler for i3bar
 
 ## DESCRIPTION
 
-**i3blocks** allows to easily describe blocks in a simple format, and
+**i3blocks** allows one to easily describe blocks in a simple format, and
 generate a status line for i3bar(1). It handles clicks, signals and time
 interval for user scripts.
 


### PR DESCRIPTION
Debian's lintian tool checks for common spelling errors in packages, it
reported this one.
