### PR TITLE
Notification when battery is critically low

### DIFF
--- a/scripts/battery
+++ b/scripts/battery
@@ -67,6 +67,7 @@ if ($status eq 'Discharging') {
 	}
 
 	if ($percent < 5) {
+		system("notify-send 'Battery is critically low'");
 		exit(33);
 	}
 }


### PR DESCRIPTION
Few times my laptop turned off due full discharging. Simple notification really helps.

But this implementation has one disadvantage. User will be notified few times before full discharging (number of times depends on period in config). To prevent this we can use perl's [Storable](http://perl.yaritz.com/perl_variables.html) (save information between script execution about have we notified or not, so only one notification will be displayed). But this solution is not very clear. Let me know if you think it's better...  