### PR TITLE
don't destroy bar layout when no openvpn pid found

### DIFF
--- a/contrib/openvpn
+++ b/contrib/openvpn
@@ -50,7 +50,7 @@ sub print_output {
     foreach (@pid_files) {
         # Get current PID
         $pid=0;
-        open(PID, '<', $_);
+        open(PID, '<', $_) || next;
         while(<PID>) {
             chomp $_;
             $pid = $_;


### PR DESCRIPTION
When there are no PID files found, `glob` will return the pattern itself and the `open` fails with a closed filehandle.