### PR TITLE
open alsamixer after left-clicking in the volume block

### DIFF
--- a/scripts/volume
+++ b/scripts/volume
@@ -62,6 +62,7 @@ format() {
 #------------------------------------------------------------------------
 
 case $BLOCK_BUTTON in
+  1) i3-sensible-terminal -e alsamixer ;;
   3) amixer -q -D $MIXER sset $SCONTROL $(capability) toggle ;;  # right click, mute/unmute
   4) amixer -q -D $MIXER sset $SCONTROL $(capability) ${STEP}+ unmute ;; # scroll up, increase
   5) amixer -q -D $MIXER sset $SCONTROL $(capability) ${STEP}- unmute ;; # scroll down, decrease


### PR DESCRIPTION
- `alsamixer` is compatible with pulseaudio, so users of alsa and pulse would both benefit from this change;
- `i3-sensible-terminal` is probably better than assuming gnome-terminal, urxvt, etc, I believe.