### PR TITLE
add network speed (netspeed) contrib script

### DIFF
--- a/contrib/config
+++ b/contrib/config
@@ -11,6 +11,14 @@ command=$SCRIPT_DIR/$BLOCK_NAME
 interval=5
 signal=10
 
+# Network speed support
+#
+# Measure the network speed of a specific network interface at small
+# intervals.
+[netspeed]
+instance=eth0
+interval=3
+
 # OpenVPN support
 #
 # Support multiple VPN, with colors.

--- a/contrib/netspeed
+++ b/contrib/netspeed
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Copyright (C) 2012 Stefan Breunig <stefan+measure-net-speed@mathphys.fsk.uni-heidelberg.de>
 # Copyright (C) 2014 kaueraal
-# Copyright (C) 2015 Thiago Perrotta <thiagoperrotta95@gmail.com>
+# Copyright (C) 2015 Thiago Perrotta <perrotta dot thiago at poli dot ufrj dot br>
 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -16,26 +16,23 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# Set instance=NETWORK_INTEFACE, e.g, instance=eth0 in your i3blocks config.
+INTERFACE="${BLOCK_INSTANCE:-eth0}"
 
-if [ -z "$BLOCK_INSTANCE" ]
-  then echo 'please give $BLOCK_INSTANCE'
-fi
-
-if ! [ -e "/sys/class/net/${BLOCK_INSTANCE}/operstate" ] || ! [ "`cat /sys/class/net/${BLOCK_INSTANCE}/operstate`" = "up" ]
+# Issue #36 compliant.
+if ! [ -e "/sys/class/net/${INTERFACE}/operstate" ] || ! [ "`cat /sys/class/net/${INTERFACE}/operstate`" = "up" ]
 then
-    echo "$BLOCK_INSTANCE down"
-    echo "$BLOCK_INSTANCE down"
+    echo "$INTERFACE down"
+    echo "$INTERFACE down"
     echo "#FF0000"
     exit 0
 fi
 
 # path to store the old results in
-path="/dev/shm/$(basename $0)-${BLOCK_INSTANCE}"
+path="/dev/shm/$(basename $0)-${INTERFACE}"
 
 # grabbing data for each adapter.
-read rx < "/sys/class/net/${BLOCK_INSTANCE}/statistics/rx_bytes"
-read tx < "/sys/class/net/${BLOCK_INSTANCE}/statistics/tx_bytes"
+read rx < "/sys/class/net/${INTERFACE}/statistics/rx_bytes"
+read tx < "/sys/class/net/${INTERFACE}/statistics/tx_bytes"
 
 # get time
 time=$(date +%s)
@@ -74,7 +71,7 @@ if [[ "${time_diff}" -gt 0 ]]; then
     echo -n "${rx_kib} K↓"
   fi
 
-  echo -n "  "
+  echo -n " "
 
   # outgoing
   tx_kib=$(( $tx_rate >> 10 ))
@@ -84,5 +81,5 @@ if [[ "${time_diff}" -gt 0 ]]; then
     echo -n "${tx_kib} K↑"
   fi
 else
-  echo -n " ? "
+  echo -n "?"
 fi

--- a/contrib/netspeed
+++ b/contrib/netspeed
@@ -1,0 +1,88 @@
+#!/bin/bash
+# Copyright (C) 2012 Stefan Breunig <stefan+measure-net-speed@mathphys.fsk.uni-heidelberg.de>
+# Copyright (C) 2014 kaueraal
+# Copyright (C) 2015 Thiago Perrotta <thiagoperrotta95@gmail.com>
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Set instance=NETWORK_INTEFACE, e.g, instance=eth0 in your i3blocks config.
+
+if [ -z "$BLOCK_INSTANCE" ]
+  then echo 'please give $BLOCK_INSTANCE'
+fi
+
+if ! [ -e "/sys/class/net/${BLOCK_INSTANCE}/operstate" ] || ! [ "`cat /sys/class/net/${BLOCK_INSTANCE}/operstate`" = "up" ]
+then
+    echo "$BLOCK_INSTANCE down"
+    echo "$BLOCK_INSTANCE down"
+    echo "#FF0000"
+    exit 0
+fi
+
+# path to store the old results in
+path="/dev/shm/$(basename $0)-${BLOCK_INSTANCE}"
+
+# grabbing data for each adapter.
+read rx < "/sys/class/net/${BLOCK_INSTANCE}/statistics/rx_bytes"
+read tx < "/sys/class/net/${BLOCK_INSTANCE}/statistics/tx_bytes"
+
+# get time
+time=$(date +%s)
+
+# write current data if file does not exist. Do not exit, this will cause
+# problems if this file is sourced instead of executed as another process.
+if ! [[ -f "${path}" ]]; then
+  echo "${time} ${rx} ${tx}" > "${path}"
+  chmod 0666 "${path}"
+fi
+
+# read previous state and update data storage
+read old < "${path}"
+echo "${time} ${rx} ${tx}" > "${path}"
+
+# parse old data and calc time passed
+old=(${old//;/ })
+time_diff=$(( $time - ${old[0]} ))
+
+# sanity check: has a positive amount of time passed
+if [[ "${time_diff}" -gt 0 ]]; then
+  # calc bytes transferred, and their rate in byte/s
+  rx_diff=$(( $rx - ${old[1]} ))
+  tx_diff=$(( $tx - ${old[2]} ))
+  rx_rate=$(( $rx_diff / $time_diff ))
+  tx_rate=$(( $tx_diff / $time_diff ))
+
+  # shift by 10 bytes to get KiB/s. If the value is larger than
+  # 1024^2 = 1048576, then display MiB/s instead
+
+  # incoming
+  rx_kib=$(( $rx_rate >> 10 ))
+  if [[ "$rx_rate" -gt 1048576 ]]; then
+    printf '%s M↓' "`echo "scale=1; $rx_kib / 1024" | bc`"
+  else
+    echo -n "${rx_kib} K↓"
+  fi
+
+  echo -n "  "
+
+  # outgoing
+  tx_kib=$(( $tx_rate >> 10 ))
+  if [[ "$tx_rate" -gt 1048576 ]]; then
+    printf '%s M↑' "`echo "scale=1; $tx_kib / 1024" | bc`"
+  else
+    echo -n "${tx_kib} K↑"
+  fi
+else
+  echo -n " ? "
+fi


### PR DESCRIPTION
I've been using this script for quite some time and I decided it was stable (and convenient) enough, so I'm sharing it with the i3blocks community.

It was taken originally from [here](http://code.stapelberg.de/git/i3status/tree/contrib/measure-net-speed.bash). After a while, @kaueraal improved it for i3blocks (see [this](https://github.com/thiagowfx/dotfiles/commit/4020fc4259c9b39b34e3b532951042233e3e62d8) commit in my dotfiles repo). Then I tweaked it a little bit and finally finished its port to i3blocks.

No external dependencies; just `bash` is sufficient. It should work with several Linux distributions (I tested it on Arch Linux in particular).

Also, feel free to change the default interval value from the sample config file. From my experience, 2 or 3 seconds are good ones, but a more conservative approach such as 5 or 10 wouldn't hurt either.