### PR TITLE
Implements `output={plain,json}` option, so commands can output JSON

### DIFF
--- a/block.c
+++ b/block.c
@@ -261,22 +261,21 @@ block_reap(struct block *block)
 
 	} else {
 		/* JSON parsing: parse object containing PROPERTIES pairs */
-		int start, length;
+		int start, length, size;
 
-#define MIN(a, b) (a < b ? a : b)
 #define JSONPARSE(_name, _size, _flags) \
 	if ((_flags) & PROP_I3BAR) { \
 		json_parse(buf, #_name, &start, &length); \
 		if (start > 0) { \
-			strncpy(props->_name, buf + start, MIN(_size, length)); \
-			props->_name[length] = '\0'; \
+			size = _size < length ? _size : length; \
+			strncpy(props->_name, buf + start, size); \
+			props->_name[size] = '\0'; \
 		} \
 	}
 
 		PROPERTIES(JSONPARSE);
 
 #undef JSONPARSE
-#undef MIN
 
 	}
 

--- a/block.h
+++ b/block.h
@@ -32,6 +32,9 @@
 #define INTER_ONCE	-1
 #define INTER_REPEAT	-2
 
+#define OUTPUT_PLAIN	0
+#define OUTPUT_JSON	1
+
 /* Block command exit codes */
 #define EXIT_URGENT	'!' /* 33 */
 #define EXIT_ERR_INTERNAL	66
@@ -51,6 +54,7 @@
 	_(interval,              8,                 PROP_STRING | PROP_NUMBER) \
 	_(signal,                8,                 PROP_NUMBER) \
 	_(label,                 32,                PROP_STRING) \
+	_(output,                6,                 PROP_STRING | PROP_NUMBER) \
 
 struct properties {
 #define DEFINE(_name, _size, _flags) char _name[_size];
@@ -65,6 +69,7 @@ struct block {
 	/* Shortcuts */
 	int interval;
 	unsigned signal;
+	unsigned output;
 
 	/* Runtime info */
 	unsigned long timestamp;

--- a/json.c
+++ b/json.c
@@ -110,6 +110,8 @@ json_parse(const char *json, const char *name, int *start, int *len)
 	char *here = strstr(json, key);
 	if (here) {
 		here += keylen + 1;
+		while (*here == ' ' || *here == '\t' || *here == '\n')
+			here++;
 		if (*here == '"') {
 			/* string */
 			here++;


### PR DESCRIPTION
Also, `json_parse` was not handling pre-value whitespaces (see example below). This PR also fixes that.

    {"foo":   "bar"}
