### PR TITLE
mediaplayer: /bin/perl => /usr/bin/perl

### DIFF
--- a/scripts/mediaplayer
+++ b/scripts/mediaplayer
@@ -1,4 +1,4 @@
-#!/bin/perl
+#!/usr/bin/perl
 # Copyright (C) 2014 Tony Crisci <tony@dubstepdish.com>
 
 # This program is free software: you can redistribute it and/or modify


### PR DESCRIPTION
the perl binary will usually be installed as /usr/bin/perl, and then symlinked
to /bin/perl. This is also how the other perl scripts are written in i3blocks.