### PR TITLE
Allow empty lines for plain text updates

### DIFF
--- a/src/block.c
+++ b/src/block.c
@@ -126,11 +126,8 @@ linecpy(char **lines, char *dest, size_t size)
 	if (newline)
 		*newline = '\0';
 
-	/* if text in non-empty, copy it */
-	if (**lines) {
-		strncpy(dest, *lines, size);
-		*lines += strlen(dest);
-	}
+	strncpy(dest, *lines, size);
+	*lines += strlen(dest);
 
 	/* increment if next char is non-null */
 	if (*(*lines + 1))

--- a/src/io.c
+++ b/src/io.c
@@ -81,8 +81,12 @@ io_readline(int fd, char *buffer, size_t size)
 	int nr = 0;
 	char c;
 
-	while (nr < size && read_nonblock(fd, &c, 1) > 0 && c != '\n')
+	while (nr < size && read_nonblock(fd, &c, 1) > 0) {
 		buffer[nr++] = c;
+		if (c == '\n') {
+			break;
+		}
+    }
 
 	return nr;
 }


### PR DESCRIPTION
An empty line from a blocklet should probably not be ignored. For instance in the case of "xtitle -s" an empty line actually means the title of the actual window changed to being empty.