### PR TITLE
Update volume meter more than once

### DIFF
--- a/i3blocks.conf
+++ b/i3blocks.conf
@@ -38,7 +38,7 @@ label=VOL
 #label=♪
 instance=Master
 #instance=PCM
-interval=once
+interval=5
 signal=10
 
 # Memory usage


### PR DESCRIPTION
Why would it be useful to display the volume and *never* update the value?
I'm suggesting 5 seconds interval as not to increase the refresh rate of the default conf (I use 1 second, myself).