### PR TITLE
Expose $BLOCK_INTERVAL to blocklets

### DIFF
--- a/i3blocks.1.ronn
+++ b/i3blocks.1.ronn
@@ -157,6 +157,9 @@ eventually an empty string as the value.
   * `BLOCK_INSTANCE`:
     An optional argument to the script.
 
+  * `BLOCK_INTERVAL`:
+    The interval that the block is set to update with (see `interval` above).
+
   * `BLOCK_BUTTON`:
     Mouse button (1, 2 or 3) if the block was clicked.
 

--- a/include/block.h
+++ b/include/block.h
@@ -84,6 +84,7 @@ struct block {
 #define INSTANCE(_block)	(_block->default_props.instance)
 #define COMMAND(_block)		(_block->default_props.command)
 #define LABEL(_block)		(_block->default_props.label)
+#define INTERVAL(_block)	(_block->default_props.interval)
 
 /* Shortcuts to update */
 #define FULL_TEXT(_block)	(_block->updated_props.full_text)

--- a/src/block.c
+++ b/src/block.c
@@ -46,6 +46,7 @@ child_setup_env(struct block *block, struct click *click)
 {
 	child_setenv(block, "BLOCK_NAME", NAME(block));
 	child_setenv(block, "BLOCK_INSTANCE", INSTANCE(block));
+	child_setenv(block, "BLOCK_INTERVAL", INTERVAL(block));
 	child_setenv(block, "BLOCK_BUTTON", click ? click->button : "");
 	child_setenv(block, "BLOCK_X", click ? click->x : "");
 	child_setenv(block, "BLOCK_Y", click ? click->y : "");


### PR DESCRIPTION
I think it may be beneficial to scripts to know what interval the script is set to be called with. For example, I am thinking of the paradigms:

    #!/bin/bash
    
    if [ "$BLOCK_INTERVAL" == "persist" ]; then
        # setup finely tuned timer
        # do_work in a loop
    else
        # just do_work once
    fi

or

    #!/bin/bash
    
    if [ "$BLOCK_INTERVAL" == "repeat" ]; then
        # wait until the right time
    fi
    # do_work

See https://github.com/kb100/i3blocks-apt-upgrades/tree/aggressive-update for the paradigm in action.