### PR TITLE
Add option to print cpu % without decimal places

### DIFF
--- a/scripts/cpu_usage
+++ b/scripts/cpu_usage
@@ -15,20 +15,32 @@ use Getopt::Long;
 my $t_warn = 50;
 my $t_crit = 80;
 my $cpu_usage = -1;
+<<<<<<< HEAD
 my $decimals = 1;
+=======
+my $decimals = 2;
+>>>>>>> 170b889... scripts: (cpu_usage) use variable decimals
 
 sub help {
     print "Usage: cpu_usage [-w <warning>] [-c <critical>] [-d <1,0>]\n";
     print "-w <percent>: warning threshold to become yellow\n";
     print "-c <percent>: critical threshold to become red\n";
+<<<<<<< HEAD
     print "-d <1,0> Print decimal places? 1 = yes (default), 0 = no \n";
+=======
+    print "-d <decimals>:  Use <decimals> decmials for percentage (default is $decimals) \n"; 
+>>>>>>> 170b889... scripts: (cpu_usage) use variable decimals
     exit 0;
 }
 
 GetOptions("help|h" => \&help,
            "w=i"    => \$t_warn,
            "c=i"    => \$t_crit,
+<<<<<<< HEAD
            "d=i"    => \$decimals
+=======
+	   "d=i"    => \$decimals
+>>>>>>> 170b889... scripts: (cpu_usage) use variable decimals
 );
 
 # Get CPU usage
@@ -46,6 +58,7 @@ $cpu_usage eq -1 and die 'Can\'t find CPU information';
 
 if($decimals == 1){
 # Print short_text, full_text
+<<<<<<< HEAD
 	printf "%.2f%%\n", $cpu_usage;
 	printf "%.2f%%\n", $cpu_usage;
 }else {
@@ -54,6 +67,10 @@ if($decimals == 1){
 	printf "%.0f%%\n", $cpu_usage;
 }
 
+=======
+printf "%.${decimals}f%%\n", $cpu_usage;
+printf "%.${decimals}f%%\n", $cpu_usage;
+>>>>>>> 170b889... scripts: (cpu_usage) use variable decimals
 # Print color, if needed
 if ($cpu_usage >= $t_crit) {
     print "#FF0000\n";

--- a/scripts/cpu_usage
+++ b/scripts/cpu_usage
@@ -15,17 +15,21 @@ use Getopt::Long;
 my $t_warn = 50;
 my $t_crit = 80;
 my $cpu_usage = -1;
+my $decimals = 1;
 
 sub help {
-    print "Usage: cpu_usage [-w <warning>] [-c <critical>]\n";
+    print "Usage: cpu_usage [-w <warning>] [-c <critical>] [-d <1,0>]\n";
     print "-w <percent>: warning threshold to become yellow\n";
     print "-c <percent>: critical threshold to become red\n";
+    print "-d <1,0> Print decimal places? 1 = yes (default), 0 = no \n";
     exit 0;
 }
 
 GetOptions("help|h" => \&help,
            "w=i"    => \$t_warn,
-           "c=i"    => \$t_crit);
+           "c=i"    => \$t_crit,
+           "d=i"    => \$decimals
+);
 
 # Get CPU usage
 $ENV{LC_ALL}="en_US"; # if mpstat is not run under en_US locale, things may break, so make sure it is
@@ -40,9 +44,15 @@ close(MPSTAT);
 
 $cpu_usage eq -1 and die 'Can\'t find CPU information';
 
+if($decimals == 1){
 # Print short_text, full_text
-printf "%.2f%%\n", $cpu_usage;
-printf "%.2f%%\n", $cpu_usage;
+	printf "%.2f%%\n", $cpu_usage;
+	printf "%.2f%%\n", $cpu_usage;
+}else {
+# Print with no decimal places
+	printf "%.0f%%\n", $cpu_usage;
+	printf "%.0f%%\n", $cpu_usage;
+}
 
 # Print color, if needed
 if ($cpu_usage >= $t_crit) {


### PR DESCRIPTION
Default functionality is the same, -d option takes either 1 (print decimals as before) or 0 (don't print decimals)