### PR TITLE
Fix memory script 'not enough argument' error

### DIFF
--- a/scripts/memory
+++ b/scripts/memory
@@ -48,10 +48,10 @@ END {
 	pct=used/total*100
 
 	# full text
-	printf("%.1fG/%.1fG (%.f%)\n", used, total, pct)
+	printf("%.1fG/%.1fG (%.f%%)\n", used, total, pct)
 
 	# short text
-	printf("%.f%\n", pct)
+	printf("%.f%%\n", pct)
 
 	# color
 	if (pct > 90) {


### PR DESCRIPTION
The `memory` script throws the following error:
awk: run time error: not enough arguments passed to printf("%.f%

This change adds necessary extra % signs to the awk format strings to fix that.