### PR TITLE
Makefile: use DATAROOTDIR for PREFIX/share

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ ifndef SYSCONFDIR
     SYSCONFDIR=$(PREFIX)/etc
   endif
 endif
+ifndef DATAROOTDIR
+  DATAROOTDIR=$(PREFIX)/share
+endif
 ifndef LIBEXECDIR
   LIBEXECDIR=$(PREFIX)/libexec
 endif
@@ -54,18 +57,18 @@ clean:
 install: all man
 	install -m 755 -d $(DESTDIR)$(PREFIX)/bin
 	install -m 755 -d $(DESTDIR)$(SYSCONFDIR)
-	install -m 755 -d $(DESTDIR)$(PREFIX)/share/man/man1
+	install -m 755 -d $(DESTDIR)$(DATAROOTDIR)/man/man1
 	install -m 755 -d $(DESTDIR)$(LIBEXECDIR)/$(PROGRAM)
 	install -m 755 $(PROGRAM) $(DESTDIR)$(PREFIX)/bin/$(PROGRAM)
 	sed 's,$$SCRIPT_DIR,$(LIBEXECDIR)/$(PROGRAM),' $(PROGRAM).conf > $(DESTDIR)$(SYSCONFDIR)/$(PROGRAM).conf
 	chmod 644 $(DESTDIR)$(SYSCONFDIR)/$(PROGRAM).conf
-	install -m 644 $(PROGRAM).1 $(DESTDIR)$(PREFIX)/share/man/man1
+	install -m 644 $(PROGRAM).1 $(DESTDIR)$(DATAROOTDIR)/man/man1
 	install -m 755 scripts/* $(DESTDIR)$(LIBEXECDIR)/$(PROGRAM)/
 
 uninstall:
 	rm -f $(DESTDIR)$(PREFIX)/bin/$(PROGRAM)
 	rm -f $(DESTDIR)$(SYSCONFDIR)/$(PROGRAM).conf
-	rm -f $(DESTDIR)$(PREFIX)/share/man/man1/$(PROGRAM).1
+	rm -f $(DESTDIR)$(DATAROOTDIR)/man/man1/$(PROGRAM).1
 	rm -rf $(DESTDIR)$(LIBEXECDIR)/$(PROGRAM)
 
 dist: clean man


### PR DESCRIPTION
Allow specifying DATAROOTDIR to make install target compatible with filesystem
layouts where architecture-independent data are separated from the prefix:
PREFIX=/usr/x86_64-pc-linux-gnu DATAROOTDIR=/usr/share