### PR TITLE
Global Color Settings

### DIFF
--- a/i3blocks.conf
+++ b/i3blocks.conf
@@ -28,6 +28,15 @@ command=$SCRIPT_DIR/$BLOCK_NAME
 separator_block_width=15
 markup=none
 
+# Status colors
+#
+# The default colors to use for indicating state. Not all blocks have been
+# configured to honor these colors.
+color_good=#00FF00
+color_fair=#FFF600
+color_degraded=#FFAE00
+color_bad=#FF0000
+
 # Volume indicator
 #
 # The first parameter sets the step (and units to display)

--- a/include/block.h
+++ b/include/block.h
@@ -57,6 +57,10 @@
 	_(signal,                8,                 PROP_NUMBER) \
 	_(label,                 32,                PROP_STRING) \
 	_(format,                8,                 PROP_STRING | PROP_NUMBER) \
+	_(color_good,            8,                 PROP_STRING) \
+	_(color_fair,            8,                 PROP_STRING) \
+	_(color_degraded,        8,                 PROP_STRING) \
+	_(color_bad,             8,                 PROP_STRING) \
 
 struct properties {
 #define DEFINE(_name, _size, _flags) char _name[_size];

--- a/scripts/battery
+++ b/scripts/battery
@@ -21,8 +21,8 @@ my $status;
 my $percent;
 my $full_text;
 my $short_text;
+my $output_color;
 my $bat_number = $ENV{BLOCK_INSTANCE} || 0;
-
 # read the first line of the "acpi" command output
 open (ACPI, "acpi -b | grep 'Battery $bat_number' |") or die;
 $acpi = <ACPI>;
@@ -55,20 +55,22 @@ print "$short_text\n";
 
 # consider color and urgent flag only on discharge
 if ($status eq 'Discharging') {
-
 	if ($percent < 20) {
-		print "#FF0000\n";
+    $output_color = $ENV{BLOCK_COLOR_BAD} || "#FF0000";
 	} elsif ($percent < 40) {
-		print "#FFAE00\n";
+    $output_color = $ENV{BLOCK_COLOR_DEGRADED} || "#FFAE00";
 	} elsif ($percent < 60) {
-		print "#FFF600\n";
+    $output_color = $ENV{BLOCK_COLOR_FAIR} || "#FFF600";
 	} elsif ($percent < 85) {
-		print "#A8FF00\n";
+    $output_color = $ENV{BLOCK_COLOR_GOOD} || "#A8FF00";
 	}
+
+	if (defined $output_color) {
+    print "$output_color\n";
+  }
 
 	if ($percent < 5) {
 		exit(33);
 	}
 }
-
 exit(0);

--- a/scripts/wifi
+++ b/scripts/wifi
@@ -36,11 +36,11 @@ echo $QUALITY% # short text
 
 # color
 if [[ $QUALITY -ge 80 ]]; then
-  echo "#00FF00"
+  echo "${BLOCK_COLOR_GOOD:-#00FF00}"
 elif [[ $QUALITY -ge 60 ]]; then
-  echo "#FFF600"
+  echo "${BLOCK_COLOR_FAIR:-#FFF600}"
 elif [[ $QUALITY -ge 40 ]]; then
-  echo "#FFAE00"
+  echo "${BLOCK_COLOR_DEGRADED:-#FFAE00}"
 else
-  echo "#FF0000"
+  echo "${BLOCK_COLOR_BAD:-#FF0000}"
 fi

--- a/scripts/wifi
+++ b/scripts/wifi
@@ -36,11 +36,11 @@ echo $QUALITY% # short text
 
 # color
 if [[ $QUALITY -ge 80 ]]; then
-    echo "#00FF00"
-elif [[ $QUALITY -lt 80 ]]; then
-    echo "#FFF600"
-elif [[ $QUALITY -lt 60 ]]; then
-    echo "#FFAE00"
-elif [[ $QUALITY -lt 40 ]]; then
-    echo "#FF0000"
+  echo "#00FF00"
+elif [[ $QUALITY -ge 60 ]]; then
+  echo "#FFF600"
+elif [[ $QUALITY -ge 40 ]]; then
+  echo "#FFAE00"
+else
+  echo "#FF0000"
 fi

--- a/scripts/wifi
+++ b/scripts/wifi
@@ -36,7 +36,7 @@ echo $QUALITY% # short text
 
 # color
 if [[ $QUALITY -ge 80 ]]; then
-    echo "#00FF00"
+    echo "$BLOCK_COLOR_GOOD"
 elif [[ $QUALITY -lt 80 ]]; then
     echo "#FFF600"
 elif [[ $QUALITY -lt 60 ]]; then

--- a/scripts/wifi
+++ b/scripts/wifi
@@ -36,7 +36,7 @@ echo $QUALITY% # short text
 
 # color
 if [[ $QUALITY -ge 80 ]]; then
-    echo "$BLOCK_COLOR_GOOD"
+    echo "#00FF00"
 elif [[ $QUALITY -lt 80 ]]; then
     echo "#FFF600"
 elif [[ $QUALITY -lt 60 ]]; then

--- a/src/block.c
+++ b/src/block.c
@@ -50,6 +50,10 @@ child_setup_env(struct block *block, struct click *click)
 	child_setenv(block, "BLOCK_BUTTON", click ? click->button : "");
 	child_setenv(block, "BLOCK_X", click ? click->x : "");
 	child_setenv(block, "BLOCK_Y", click ? click->y : "");
+	child_setenv(block, "BLOCK_COLOR_GOOD", block->default_props.color_good);
+	child_setenv(block, "BLOCK_COLOR_FAIR", block->default_props.color_fair);
+	child_setenv(block, "BLOCK_COLOR_DEGRADED", block->default_props.color_degraded);
+	child_setenv(block, "BLOCK_COLOR_BAD", block->default_props.color_bad);
 }
 
 static void


### PR DESCRIPTION
I'm new to i3blocks, but I've enjoyed using it so far. The only issue that I've run into is that there doesn't seem to be a way to share colors between blocks. This PR aims to add support for global color settings that can be used by any block. 

I also went ahead and modified the battery and wifi scripts to support the new settings.

It seems to work well on my machine and I thought others might be interested in the functionality.
