### PR TITLE
`clickcommand` added

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,22 +3,22 @@
 [![Build Status](https://travis-ci.org/vivien/i3blocks.svg?branch=master)](https://travis-ci.org/vivien/i3blocks)
 [![Join the chat at https://gitter.im/vivien/i3blocks](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/vivien/i3blocks?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-i3blocks is a highly flexible **status line** for the [i3](http://i3wm.org) 
-window manager. It handles *clicks*, *signals* and *language-agnostic* user 
+i3blocks is a highly flexible **status line** for the [i3](http://i3wm.org)
+window manager. It handles *clicks*, *signals* and *language-agnostic* user
 *scripts*.
 
-The content of each *block* (e.g. time, battery status, network state, ...) is 
-the output of a *command* provided by the user. Blocks are updated on *click*, 
-at a given *interval* of time or on a given *signal*, also specified by the 
+The content of each *block* (e.g. time, battery status, network state, ...) is
+the output of a *command* provided by the user. Blocks are updated on *click*,
+at a given *interval* of time or on a given *signal*, also specified by the
 user.
 
 It aims to respect the
-[i3bar protocol](http://i3wm.org/docs/i3bar-protocol.html), providing 
+[i3bar protocol](http://i3wm.org/docs/i3bar-protocol.html), providing
 customization such as text alignment, urgency, color, and more.
 
 - - -
 
-Here is an example of status line, showing the time updated every 5 seconds, 
+Here is an example of status line, showing the time updated every 5 seconds,
 the volume updated only when i3blocks receives a SIGRTMIN+1, and click events.
 
 ```` ini
@@ -38,10 +38,11 @@ full_text=Click me!
 command=echo button=$BLOCK_BUTTON x=$BLOCK_X y=$BLOCK_Y
 min_width=button=1 x=1366 y=768
 align=left
+clickcommand=nautilus
 ````
 
-You can use your own scripts, or the 
-[ones](https://github.com/vivien/i3blocks/tree/master/scripts) provided with 
+You can use your own scripts, or the
+[ones](https://github.com/vivien/i3blocks/tree/master/scripts) provided with
 i3blocks. Feel free to contribute and improve them!
 
 The default config will look like this:
@@ -60,22 +61,22 @@ The user contributed scripts may also use external tools:
 
 ## Documentation
 
-For more information about how it works, please refer to the 
+For more information about how it works, please refer to the
 [**manpage**](http://vivien.github.io/i3blocks).
 
 You can also take a look at the
-[i3bar protocol](http://i3wm.org/docs/i3bar-protocol.html) to see what 
+[i3bar protocol](http://i3wm.org/docs/i3bar-protocol.html) to see what
 possibilities it offers you.
 
-Take a look at the [wiki](https://github.com/vivien/i3blocks/wiki) for examples 
-of blocks and screenshots. If you want to share your ideas and status line, 
+Take a look at the [wiki](https://github.com/vivien/i3blocks/wiki) for examples
+of blocks and screenshots. If you want to share your ideas and status line,
 feel free to edit it!
 
 ## Installation
 
 i3blocks may already be packaged for your distribution:
 
-  * Archlinux: [i3blocks](https://aur.archlinux.org/packages/i3blocks) and 
+  * Archlinux: [i3blocks](https://aur.archlinux.org/packages/i3blocks) and
   [i3blocks-git](https://aur.archlinux.org/packages/i3blocks-git) AURs.
   * Gentoo: [ebuild](https://github.com/Sabayon-Labs/spike-community-overlay/tree/master/x11-misc/i3blocks)
   * Debian: [i3blocks](https://packages.debian.org/i3blocks) and Ubuntu: [i3blocks](http://packages.ubuntu.com/i3blocks)

--- a/include/block.h
+++ b/include/block.h
@@ -53,6 +53,7 @@
 	_(separator_block_width, 8,    PROP_I3BAR | PROP_NUMBER) \
 	_(markup,                8,    PROP_I3BAR | PROP_STRING) \
 	_(command,               1024,              PROP_STRING) \
+	_(clickcommand,					 1024,							PROP_STRING) \
 	_(interval,              8,                 PROP_STRING | PROP_NUMBER) \
 	_(signal,                8,                 PROP_NUMBER) \
 	_(label,                 32,                PROP_STRING) \
@@ -85,6 +86,7 @@ struct block {
 #define COMMAND(_block)		(_block->default_props.command)
 #define LABEL(_block)		(_block->default_props.label)
 #define INTERVAL(_block)	(_block->default_props.interval)
+#define CLICKCOMMAND(_block) (_block->default_props.clickcommand)
 
 /* Shortcuts to update */
 #define FULL_TEXT(_block)	(_block->updated_props.full_text)
@@ -102,5 +104,6 @@ void block_setup(struct block *);
 void block_spawn(struct block *, struct click *);
 void block_reap(struct block *);
 void block_update(struct block *);
+void block_click(struct block *);
 
 #endif /* _BLOCK_H */

--- a/src/block.c
+++ b/src/block.c
@@ -389,9 +389,21 @@ void block_click(struct block *block)
 
 	static const char * const shell = "/bin/sh";
 
-	pid_t pid;
-	pid = fork ();
-
-	if (pid == 0)
-		execl (shell, shell, "-c", CLICKCOMMAND(block), NULL);
+	int status;
+  pid_t pid;
+  pid = fork ();
+  if (pid == 0)
+    {
+      /* This is the child process.  Execute the shell command. */
+      execl (shell, shell, "-c", CLICKCOMMAND(block), NULL);
+			berrorx(block, "exec(%s -c %s)", shell, COMMAND(block));
+			_exit(EXIT_ERR_INTERNAL);
+    }
+  else if (pid < 0)
+    /* The fork failed.  Report failure.  */
+    status = -1;
+  else
+    /* This is the parent process.  Wait for the child to complete.  */
+    if (waitpid (pid, &status, 0) != pid)
+      status = -1;
 }

--- a/src/block.c
+++ b/src/block.c
@@ -291,6 +291,9 @@ block_spawn(struct block *block, struct click *click)
 	if (!click)
 		block->timestamp = now;
 
+	if (click)
+		block_click(block);
+
 	bdebug(block, "forked child %d at %ld", block->pid, now);
 }
 
@@ -379,4 +382,16 @@ void block_setup(struct block *block)
 
 #undef ARGS
 #undef PLACEHOLDERS
+}
+
+void block_click(struct block *block)
+{
+
+	static const char * const shell = "/bin/sh";
+
+	pid_t pid;
+	pid = fork ();
+
+	if (pid == 0)
+		execl (shell, shell, "-c", CLICKCOMMAND(block), NULL);
 }


### PR DESCRIPTION
I my daily use of i3blocks I missed this feature:
``ìni
[memory]
clickcommand=gnome-system-monitor

```
so I added it.

It sould work similar to command, but it will be executed when - and **only** when you click on it.
That makes it easy to open programms that show more information.

I am not a c expert so appologies for possibly bad code :P.
```
