### PR TITLE
Promote i3blocks-contrib in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ You can also take a look at the
 [i3bar protocol](http://i3wm.org/docs/i3bar-protocol.html) to see what 
 possibilities it offers you.
 
-Take a look at the [wiki](https://github.com/vivien/i3blocks/wiki) for examples 
+Take a look at the [wiki](https://github.com/vivien/i3blocks/wiki) and sister
+project [i3blocks-contrib](https://github.com/vivien/i3blocks-contrib) for examples 
 of blocks and screenshots. If you want to share your ideas and status line, 
 feel free to edit it!
 


### PR DESCRIPTION
This commit puts a link to the i3blocks-contrib project directly in the
README. Previously a link was only found in the wiki. This brings users
one click closer to i3blocks-contrib, giving them easier access to many
blocklet examples, as well as promoting use of and contributions to the
sister project.
