### PR TITLE
Makefile: make the build reproducible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ CPPFLAGS += -DSYSCONFDIR=\"$(SYSCONFDIR)\"
 CPPFLAGS += -DVERSION=\"${VERSION}\"
 CFLAGS += -std=gnu99 -Iinclude -Wall -Werror=format-security
 
-OBJS := $(wildcard src/*.c)
+OBJS := $(sort $(wildcard src/*.c))
 OBJS := $(OBJS:.c=.o)
 
 %.o: %.c %.h


### PR DESCRIPTION
This is done by sorting the list of sources, which will later turned into list
of objects (thus sent to the linker).

$(wildcard ) in a makefile is not stable, it's output depends on readdir().
The latter cannot be relied on for sorting when used on disorderfs for example.

This is easily fixed by wrapping it in $(sort )

Thanks to @mapreri for the patch !