### PR TITLE
added a check for bc

### DIFF
--- a/scripts/bandwidth
+++ b/scripts/bandwidth
@@ -83,13 +83,19 @@ tx_diff=$(( $tx - ${old[2]} ))
 rx_rate=$(( $rx_diff / $time_diff ))
 tx_rate=$(( $tx_diff / $time_diff ))
 
+# check to make sure bc is installed
+# otherwise, show KiB/s no matter what
+if [ -f /usr/bin/bc ]; then
+    bc=true
+fi
+
 # shift by 10 bytes to get KiB/s. If the value is larger than
 # 1024^2 = 1048576, then display MiB/s instead
-
+    
 # incoming
 echo -n "$INLABEL"
 rx_kib=$(( $rx_rate >> 10 ))
-if [[ "$rx_rate" -gt 1048576 ]]; then
+if [ "$bc" = "true" ] && [[ "$rx_rate" -gt 1048576 ]]; then
   printf '%sM' "`echo "scale=1; $rx_kib / 1024" | bc`"
 else
   echo -n "${rx_kib}K"
@@ -100,7 +106,7 @@ echo -n " "
 # outgoing
 echo -n "$OUTLABEL"
 tx_kib=$(( $tx_rate >> 10 ))
-if [[ "$tx_rate" -gt 1048576 ]]; then
+if [ "$bc" = "true" ] && [[ "$tx_rate" -gt 1048576 ]]; then
   printf '%sM' "`echo "scale=1; $tx_kib / 1024" | bc`"
 else
   echo -n "${tx_kib}K"

--- a/scripts/bandwidth
+++ b/scripts/bandwidth
@@ -83,22 +83,16 @@ tx_diff=$(( $tx - ${old[2]} ))
 rx_rate=$(( $rx_diff / $time_diff ))
 tx_rate=$(( $tx_diff / $time_diff ))
 
-# check to make sure bc is installed
-# otherwise, show KiB/s no matter what
-if [ -f /usr/bin/bc ]; then
-    bc=true
-fi
-
 # shift by 10 bytes to get KiB/s. If the value is larger than
 # 1024^2 = 1048576, then display MiB/s instead
     
 # incoming
 echo -n "$INLABEL"
 rx_kib=$(( $rx_rate >> 10 ))
-if [ "$bc" = "true" ] && [[ "$rx_rate" -gt 1048576 ]]; then
-  printf '%sM' "`echo "scale=1; $rx_kib / 1024" | bc`"
+if hash bc 2>/dev/null && [[ "$rx_rate" -gt 1048576 ]]; then
+    printf '%sM' "`echo "scale=1; $rx_kib / 1024" | bc`"
 else
-  echo -n "${rx_kib}K"
+    echo -n "${rx_kib}K"
 fi
 
 echo -n " "
@@ -106,8 +100,8 @@ echo -n " "
 # outgoing
 echo -n "$OUTLABEL"
 tx_kib=$(( $tx_rate >> 10 ))
-if [ "$bc" = "true" ] && [[ "$tx_rate" -gt 1048576 ]]; then
-  printf '%sM' "`echo "scale=1; $tx_kib / 1024" | bc`"
+if hash bc 2>/dev/null && [[ "$tx_rate" -gt 1048576 ]]; then
+    printf '%sM' "`echo "scale=1; $tx_kib / 1024" | bc`"
 else
-  echo -n "${tx_kib}K"
+    echo -n "${tx_kib}K"
 fi


### PR DESCRIPTION
bc doesn't come installed in base or base-devel for Arch users, so in the case that it is not installed, don't convert KiB/s to MiB/s. 