### PR TITLE
scripts: (battery) try to guess status by quering ac adapter

### DIFF
--- a/scripts/battery
+++ b/scripts/battery
@@ -19,6 +19,7 @@ use utf8;
 my $acpi;
 my $status;
 my $percent;
+my $ac_adapt;
 my $full_text;
 my $short_text;
 my $bat_number = $ENV{BLOCK_INSTANCE} || 0;
@@ -41,6 +42,20 @@ if ($status eq 'Discharging') {
 	$full_text .= ' DIS';
 } elsif ($status eq 'Charging') {
 	$full_text .= ' CHR';
+} elsif ($status eq 'Unknown') {
+	open (AC_ADAPTER, "acpi -a |") or die;
+	$ac_adapt = <AC_ADAPTER>;
+	close(AC_ADAPTER);
+
+	if ($ac_adapt =~ /: ([\w-]+)/) {
+		$ac_adapt = $1;
+
+		if ($ac_adapt eq 'on-line') {
+			$full_text .= ' CHR';
+		} elsif ($ac_adapt eq 'off-line') {
+			$full_text .= ' DIS';
+		}
+	}
 }
 
 $short_text = $full_text;


### PR DESCRIPTION
The battery script uses `acpi -b` to query to battery status, but the
status might be 'Unknown', especially when the AC adapter has just been
(un)plugged. The script now tries to query the AC adapter status when
that battery status is encountered.

With that modification, it is possible to hook on ACPI events to refresh
the battery status, and make i3blocks more reactive and display useful
information. For example, with `acpid` and the following event files:

  $ cat /etc/acpid/events/battery
  event=ac_adapter
  action=pkill i3blocks -RTMIN+11

and hooking the battery block on signal 11, the battery block will be
refreshed when the AC adapter is (un)plugged.