### PR TITLE
Added desktop notification when battery is low

### DIFF
--- a/scripts/battery
+++ b/scripts/battery
@@ -15,6 +15,7 @@
 use strict;
 use warnings;
 use utf8;
+use Desktop::Notify;
 
 my $acpi;
 my $status;
@@ -83,6 +84,15 @@ if ($status eq 'Discharging') {
 
 	if ($percent < 5) {
 		exit(33);
+	}
+	if ($percent < 15) {
+		my $notify = new Desktop::Notify;
+		my $notification = $notify->create(
+			summary => "Low Battery ($percent)\n",
+			body => "You must plug in your adapter",
+			timeout => 2000,
+		);
+		$notification->show();
 	}
 }
 


### PR DESCRIPTION
Desktop notification enables when battery level is less than 10%.  Requires Desktop::Notify package https://metacpan.org/pod/Desktop::Notify.
