### PR TITLE
Adjust scripts/volume to handle scontrols without on/off status.

### DIFF
--- a/scripts/volume
+++ b/scripts/volume
@@ -51,8 +51,8 @@ volume() {
 }
 
 format() {
-  perl_filter='if (/.*\[(\d+%)\] (\[(-?\d+.\d+dB)\] )?\[(on|off)\]/)'
-  perl_filter+='{CORE::say $4 eq "off" ? "MUTE" : "'
+  perl_filter='if (/.*\[(\d+%)\]( \[(-?\d+.\d+dB)\])?( \[off\])?/)'
+  perl_filter+='{CORE::say $4 eq " [off]" ? "MUTE" : "'
   # If dB was selected, print that instead
   perl_filter+=$([[ $STEP = *dB ]] && echo '$3' || echo '$1')
   perl_filter+='"; exit}'


### PR DESCRIPTION
This adjustment enables scripts/volume to handle simple mixer controls without on/off status, i.e. situations where `amixer -D $MIXER get $SCONTROL $(capability)` returns something like

```
Simple mixer control 'PCM',0
  Capabilities: pvolume
  Playback channels: Front Left - Front Right
  Limits: Playback 0 - 255
  Mono:
  Front Left: Playback 164 [64%] [-18.20dB]
  Front Right: Playback 164 [64%] [-18.20dB]
```

in contrast to a more common output like

```
Simple mixer control 'Master',0
  Capabilities: pvolume pvolume-joined pswitch pswitch-joined
  Playback channels: Mono
  Limits: Playback 0 - 87
  Mono: Playback 57 [66%] [-22.50dB] [on]
```
