### PR TITLE
new README, i3blocks is now in the official arch linux repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ feel free to edit it!
 
 i3blocks may already be packaged for your distribution:
 
-  * Archlinux: [i3blocks](https://aur.archlinux.org/packages/i3blocks) and 
-  [i3blocks-git](https://aur.archlinux.org/packages/i3blocks-git) AURs.
+  * Archlinux: [i3blocks](https://www.archlinux.org/packages/community/x86_64/i3blocks/) in the official repos and 
+  [i3blocks-git](https://aur.archlinux.org/packages/i3blocks-git) in the AUR 
   * Gentoo: [ebuild](https://github.com/Sabayon-Labs/spike-community-overlay/tree/master/x11-misc/i3blocks)
   * Debian: [i3blocks](https://packages.debian.org/i3blocks) and Ubuntu: [i3blocks](http://packages.ubuntu.com/i3blocks)
 


### PR DESCRIPTION
Hello,
I have moved i3blocks to the arch linux community repository. Therefore you can install it now via `pacman -S i3blocks`. 