### PR TITLE
Changed timestamps and other timing to CLOCK_MONOTONIC.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ PROGRAM = i3blocks
 CPPFLAGS += -DSYSCONFDIR=\"$(SYSCONFDIR)\"
 CPPFLAGS += -DVERSION=\"${VERSION}\"
 CFLAGS += -std=gnu99 -Iinclude -Wall -Werror=format-security
+LDFLAGS += -lrt
 
 OBJS := $(sort $(wildcard src/*.c))
 OBJS := $(OBJS:.c=.o)
@@ -43,7 +44,7 @@ debug: CFLAGS += -g
 debug: $(PROGRAM)
 
 $(PROGRAM): ${OBJS}
-	$(CC) $(LDFLAGS) -o $@ $^
+	$(CC) -o $@ $^ $(LDFLAGS)
 	@echo " LD $@"
 
 man: $(PROGRAM).1

--- a/include/block.h
+++ b/include/block.h
@@ -76,7 +76,7 @@ struct block {
 	unsigned format;
 
 	/* Runtime info */
-	unsigned long timestamp;
+	struct timespec timestamp;
 	pid_t pid;
 	int out, err;
 };

--- a/src/bar.c
+++ b/src/bar.c
@@ -74,10 +74,11 @@ bar_poll_outdated(struct bar *bar)
 		struct block *block = bar->blocks + i;
 
 		if (block->interval > 0) {
-			const unsigned long now = time(NULL);
-			const unsigned long next_update = block->timestamp + block->interval;
+			struct timespec now;
+			clock_gettime(CLOCK_MONOTONIC, &now);
+			const unsigned long next_update = block->timestamp.tv_sec + block->interval;
 
-			if (((long) (next_update - now)) <= 0) {
+			if (((long) (next_update - now.tv_sec)) <= 0) {
 				bdebug(block, "outdated");
 				block_spawn(block, NULL);
 			}
@@ -121,7 +122,9 @@ bar_poll_exited(struct bar *bar)
 				bdebug(block, "exited");
 				block_reap(block);
 				if (block->interval == INTER_REPEAT) {
-					if (block->timestamp == time(NULL))
+					struct timespec now;
+					clock_gettime(CLOCK_MONOTONIC, &now);
+					if (block->timestamp.tv_sec == now.tv_sec)
 						berror(block, "loop too fast");
 					block_spawn(block, NULL);
 				} else if (block->interval == INTER_PERSIST) {

--- a/src/block.c
+++ b/src/block.c
@@ -234,7 +234,8 @@ block_update(struct block *block)
 void
 block_spawn(struct block *block, struct click *click)
 {
-	const unsigned long now = time(NULL);
+	struct timespec now;
+	clock_gettime(CLOCK_MONOTONIC, &now);
 	int out[2], err[2];
 
 	if (!*COMMAND(block)) {
@@ -292,7 +293,7 @@ block_spawn(struct block *block, struct click *click)
 	if (!click)
 		block->timestamp = now;
 
-	bdebug(block, "forked child %d at %ld", block->pid, now);
+	bdebug(block, "forked child %d at %ld", block->pid, now.tv_sec);
 }
 
 void


### PR DESCRIPTION
Addresses blocks not updating upon changing time. #241
Added LDFlags to Makefile to link clock_gettime (requires LDFLAGS be placed at end of gcc command)