### PR TITLE
Include BLOCK_COLOR in environment

### DIFF
--- a/i3blocks.1.md
+++ b/i3blocks.1.md
@@ -174,6 +174,9 @@ eventually an empty string as the value.
 `BLOCK_INSTANCE`
 :   An optional argument to the script.
 
+`BLOCK_COLOR`
+:   The color specified in the configuration for the block.
+
 `BLOCK_BUTTON`
 :   Mouse button (1, 2 or 3) if the block was clicked.
 

--- a/include/block.h
+++ b/include/block.h
@@ -87,6 +87,7 @@ struct block {
 #define COMMAND(_block)		(_block->default_props.command)
 #define LABEL(_block)		(_block->default_props.label)
 #define INTERVAL(_block)	(_block->default_props.interval)
+#define COLOR(_block)		(_block->default_props.color)
 
 /* Shortcuts to update */
 #define FULL_TEXT(_block)	(_block->updated_props.full_text)

--- a/src/block.c
+++ b/src/block.c
@@ -47,6 +47,7 @@ child_setup_env(struct block *block, struct click *click)
 	child_setenv(block, "BLOCK_NAME", NAME(block));
 	child_setenv(block, "BLOCK_INSTANCE", INSTANCE(block));
 	child_setenv(block, "BLOCK_INTERVAL", INTERVAL(block));
+	child_setenv(block, "BLOCK_COLOR", COLOR(block));
 	child_setenv(block, "BLOCK_BUTTON", click ? click->button : "");
 	child_setenv(block, "BLOCK_X", click ? click->x : "");
 	child_setenv(block, "BLOCK_Y", click ? click->y : "");


### PR DESCRIPTION
This will make it easier to create portable, more predictable blocklets, especially when using Pango, since the user's desired color can be accessed directly.