### PR TITLE
Remove local restriction from disk script

### DIFF
--- a/scripts/disk
+++ b/scripts/disk
@@ -17,7 +17,7 @@
 DIR="${BLOCK_INSTANCE:-$HOME}"
 ALERT_LOW="${1:-10}" # color will turn red under this value (default: 10%)
 
-df -h -P -l "$DIR" | awk -v alert_low=$ALERT_LOW '
+df -h -P "$DIR" | awk -v alert_low=$ALERT_LOW '
 /\/.*/ {
 	# full text
 	print $4


### PR DESCRIPTION
Currently, the disk script fails to scan a disk if it's over the network. If a user has configured i3blocks to look at a specific disk, presumably he knows if it's local or not and can make a judgement as to whether he wants this behaviour. Consequently, we remove the -l option from df to allow remote disks to be monitored.

Perhaps this should be configurable, though.