### PR TITLE
Don't print an initial empty block

### DIFF
--- a/src/json.c
+++ b/src/json.c
@@ -85,7 +85,7 @@ print_block(struct block *block)
 #define PRINT(_name, _size, _flags) \
 	print_prop(#_name, block->updated_props._name, _flags); \
 
-	fprintf(stdout, ",{\"\":\"\"");
+	fprintf(stdout, "{\"\":\"\"");
 	PROPERTIES(PRINT);
 	fprintf(stdout, "}");
 
@@ -137,7 +137,8 @@ json_parse(const char *json, const char *name, int *start, int *len)
 void
 json_print_bar(struct bar *bar)
 {
-	fprintf(stdout, ",[{\"full_text\":\"\"}");
+	bool first = true;
+	fprintf(stdout, ",[");
 
 	for (int i = 0; i < bar->num; ++i) {
 		struct block *block = bar->blocks + i;
@@ -148,6 +149,8 @@ json_print_bar(struct bar *bar)
 			continue;
 		}
 
+		if (!first) fprintf(stdout, ",");
+		else first = false;
 		print_block(block);
 	}
 


### PR DESCRIPTION
The initial empty block is what is causing #274, because swaybar seems to be interpreting it as taking up the entire bar to the left of the actual blocks. This is arguably a bug on sway's end and not i3blocks', but AFAICT the empty block is only there to simplify the comma logic anyway.