### PR TITLE
Handle new click event parameters: relative coordinates, block size

### DIFF
--- a/i3blocks.1.md
+++ b/i3blocks.1.md
@@ -180,6 +180,13 @@ eventually an empty string as the value.
 `BLOCK_X` and `BLOCK_Y`
 :   Coordinates where the click occurred, if the block was clicked.
 
+`BLOCK_RELATIVE_X` and `BLOCK_RELATIVE_Y`
+:   Coordinates where the click occurred, with respect to the top left corner
+    of the block.
+
+`BLOCK_WIDTH` and `BLOCK_HEIGHT`
+:   Width and height (in px) of the block.
+
 Here is an example using the environment:
 
     [block]

--- a/include/click.h
+++ b/include/click.h
@@ -25,6 +25,10 @@ struct click {
 	char *button;
 	char *x;
 	char *y;
+	char *relative_x;
+	char *relative_y;
+	char *width;
+	char *height;
 };
 
 void click_parse(char *, struct click *);

--- a/src/block.c
+++ b/src/block.c
@@ -50,6 +50,10 @@ child_setup_env(struct block *block, struct click *click)
 	child_setenv(block, "BLOCK_BUTTON", click ? click->button : "");
 	child_setenv(block, "BLOCK_X", click ? click->x : "");
 	child_setenv(block, "BLOCK_Y", click ? click->y : "");
+	child_setenv(block, "BLOCK_RELATIVE_X", click ? click->relative_x : "");
+	child_setenv(block, "BLOCK_RELATIVE_Y", click ? click->relative_y : "");
+	child_setenv(block, "BLOCK_WIDTH", click ? click->width : "");
+	child_setenv(block, "BLOCK_HEIGHT", click ? click->height : "");
 }
 
 static void

--- a/src/click.c
+++ b/src/click.c
@@ -23,9 +23,12 @@
 /*
  * Parse a click, previous read from stdin.
  *
- * A click looks like this ("name" and "instance" can be absent):
+ * A click looks like this:
  *
- *     ',{"name":"foo","instance":"bar","button":1,"x":1186,"y":13}\n'
+ *     ',{"name":"foo","instance":"bar","button":1,"x":1186,"y":13,"relative_x":12,"relative_y":8,"width":50,"height":22}\n'
+ *
+ * "name" and "instance" can be absent.
+ * "relative_x", "relative_y", "width", and "height" introduced in i3 v4.15.
  *
  * Note that this function is non-idempotent. We need to parse from right to
  * left. It's ok since the JSON layout is known and fixed.
@@ -38,7 +41,15 @@ click_parse(char *json, struct click *click)
 	int bst, blen;
 	int xst, xlen;
 	int yst, ylen;
+	int rxst, rxlen;
+	int ryst, rylen;
+	int wst, wlen;
+	int hst, hlen;
 
+	json_parse(json, "height", &hst, &hlen);
+	json_parse(json, "width", &wst, &wlen);
+	json_parse(json, "relative_y", &ryst, &rylen);
+	json_parse(json, "relative_x", &rxst, &rxlen);
 	json_parse(json, "y", &yst, &ylen);
 	json_parse(json, "x", &xst, &xlen);
 	json_parse(json, "button", &bst, &blen);
@@ -54,13 +65,27 @@ click_parse(char *json, struct click *click)
 	click->button = json + bst;
 	*(click->button + blen) = '\0';
 
-	click->y = json + yst;
-	*(click->y + ylen) = '\0';
-
 	click->x = json + xst;
 	*(click->x + xlen) = '\0';
 
-	debug("parsed click: name=%s instance=%s button=%s x=%s y=%s",
+	click->y = json + yst;
+	*(click->y + ylen) = '\0';
+
+	click->relative_x = json + rxst;
+	*(click->relative_x + rxlen) = '\0';
+
+	click->relative_y = json + ryst;
+	*(click->relative_y + rylen) = '\0';
+
+	click->width = json + wst;
+	*(click->width + wlen) = '\0';
+
+	click->height = json + hst;
+	*(click->height + hlen) = '\0';
+
+	debug("parsed click: name=%s instance=%s button=%s x=%s y=%s relative_x=%s relative_y=%s width=%s height=%s",
 			click->name, click->instance,
-			click->button, click->x, click->y);
+			click->button, click->x, click->y,
+			click->relative_x, click->relative_y,
+			click->width, click->height);
 }


### PR DESCRIPTION
Some new event click parameters has been recently introduced in i3bar protocol (https://github.com/i3/i3/pull/3095, i3 v4.15):

> relative_x, relative_y
> - Coordinates where the click occurred, with respect to the top left corner of the block

> width, height
> - Width and height (in px) of the block

This PR adds corresponding `BLOCK_*` environment variables:
- `BLOCK_RELATIVE_X`
- `BLOCK_RELATIVE_Y`
- `BLOCK_WIDTH`
- `BLOCK_HEIGHT`

Usage example:
```
[demo]
full_text=click me
command=bash -c 'BARS=$((BLOCK_RELATIVE_X*20/BLOCK_WIDTH)); DOTS=$((20-BARS)); VOL=$((BLOCK_RELATIVE_X*100/BLOCK_WIDTH)); printf "%0.s▮" $(seq 1 $BARS); printf "%0.s▯" $(seq 1 $DOTS); amixer -c 1 -M set Headphone $VOL% > /dev/null; exit 0'
min_width=####################
```
