### PR TITLE
configure: ask compiler to use stdc (C99)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,6 +2,7 @@ AC_INIT([i3blocks], 1.4)
 AC_CONFIG_AUX_DIR([build-aux])
 AM_INIT_AUTOMAKE(foreign)
 AC_PROG_CC
+AC_PROG_CC_STDC
 AC_CONFIG_HEADERS([i3blocks-config.h])
 AC_CONFIG_FILES([
   Makefile


### PR DESCRIPTION
Otherwise with gcc 4.8.4 I get

```
sched.c: In function ‘longest_sleep’:
sched.c:51:2: error: ‘for’ loop initial declarations are only allowed in C99 mode
  for (int i = 1; i < bar->num; ++i)
  ^
sched.c:51:2: note: use option -std=c99 or -std=gnu99 to compile your code
```

