### PR TITLE
bar: fix conditional jump on uninitialised value

### DIFF
--- a/bar.c
+++ b/bar.c
@@ -314,6 +314,7 @@ static struct block *bar_add_block(struct bar *bar)
 	if (reloc) {
 		bar->blocks = reloc;
 		block = bar->blocks + bar->num;
+		memset(block, 0, sizeof(*block));
 		bar->num++;
 	}
 


### PR DESCRIPTION
Valgrind complains about an uninitialised value that is used in a
condition.

	==7083== Conditional jump or move depends on uninitialised value(s)
	==7083==    at 0x10B9D5: block_spawn (block.c:455)
	==7083==    by 0x10E557: sched_poll_timed (sched.c:169)
	==7083==    by 0x10E557: sched_start (sched.c:270)
	==7083==    by 0x10A49B: main (main.c:67)
	==7083==
	==7083== Conditional jump or move depends on uninitialised value(s)
	==7083==    at 0x10B84F: block_touch (block.c:254)
	==7083==    by 0x10E55F: sched_poll_timed (sched.c:170)
	==7083==    by 0x10E55F: sched_start (sched.c:270)
	==7083==    by 0x10A49B: main (main.c:67)
	==7083==

It corresponds to accesses on the two attributes of the structure block:

	static bool block_is_spawned(struct block *block)
	{
		return block->pid > 0;
	}

And:

	if (block->timestamp == now) {
		block_debug(block, "looping too fast");
		return;
	}

The issue comes from the use of realloc() that does not memset() the new
allocated value.

The new allocated block is now memset() causes all its attributes
initialized to 0.

Note: The following attributes are not directly setup in block_setup()
(they are now initialized by memset()):

	unsigned long timestamp;
	int in[2];
	int out[2];
	int err[2];
	int code;
	pid_t pid;

They may need to be initialized to another value (such as -1).