### PR TITLE
sys: fix SEGV on exit caused by an invalid write

### DIFF
--- a/sys.c
+++ b/sys.c
@@ -120,7 +120,8 @@ int sys_waitpid(pid_t pid, int *code)
 	if (rc == 0)
 		return -ECHILD;
 
-	*code = WEXITSTATUS(status);
+	if (code)
+		*code = WEXITSTATUS(status);
 
 	return 0;
 }


### PR DESCRIPTION
i3blocks crashes with a segmentation fault when it tries to exit
gracefully.

Valgrinds complains about an invalid write.

	==6417== Invalid write of size 4
	==6417==    at 0x10F28B: sys_waitpid (sys.c:123)
	==6417==    by 0x10F358: sys_waitanychild (sys.c:133)
	==6417==    by 0x10E64C: sched_start (sched.c:336)
	==6417==    by 0x10A49B: main (main.c:67)
	==6417==  Address 0x0 is not stack'd, malloc'd or (recently) free'd
	==6417==
	==6417==
	==6417== Process terminating with default action of signal 11 (SIGSEGV): dumping core
	==6417==  Access not within mapped region at address 0x0
	==6417==    at 0x10F28B: sys_waitpid (sys.c:123)
	==6417==    by 0x10F358: sys_waitanychild (sys.c:133)
	==6417==    by 0x10E64C: sched_start (sched.c:336)
	==6417==    by 0x10A49B: main (main.c:67)

The crash happens when the scheduler exits and when it reaps its
children.

The signal SEGV is raised in sys_waitpid() when the status value of the
child is returned to the caller through a pointer given in parameter
which is NULL.

The caller sys_waitanychild() calls sys_waitpid() with a NULL value as
code parameter.

	int sys_waitanychild(void)
	{
		int err;

		for (;;) {
			err = sys_waitpid(-1, NULL);
	/* called with NULL ------------------^ */
			if (err) {
				if (err == -ECHILD)
					break;
				return err;
			}
		}

		return 0;
	}

The function sys_waitpid() does not check for NULL pointer before it
writes the child status value inside.

	int sys_waitpid(pid_t pid, int *code)
	{
		int status;
		int rc;

		rc = waitpid(pid, &status, 0);
		if (rc == -1) {
			sys_errno("waitpid(%d)", pid);
			rc = -errno;
			return rc;
		}

		if (rc == 0)
			return -ECHILD;

		*code = WEXITSTATUS(status);
	/* -------------^ */
		return 0;
	}

The function sys_waitpid() now checks for NULL pointer before it writes
any value inside.