### PR TITLE
Cast const to non-const before freeing

### DIFF
--- a/bar.c
+++ b/bar.c
@@ -366,7 +366,7 @@ void bar_destroy(struct bar *bar)
 
 	for (i = 0; i < bar->num; i++) {
 		map_destroy(bar->blocks[i].env);
-		map_destroy(bar->blocks[i].config);
+		map_destroy((struct map *)bar->blocks[i].config);
 	}
 	free(bar->blocks);
 	free(bar);


### PR DESCRIPTION
To make the compiler happy, we cast each block's const config to
non-const before freeing.

One could argue that since we are freeing the memory, it should not have been const in the first place, but this only occurs on program termination, so it's somewhat a wash.