### PR TITLE
Little fix on `hostname` option for example

### DIFF
--- a/docs/README.adoc
+++ b/docs/README.adoc
@@ -30,7 +30,7 @@ color=#A4C2F4
 
 # Query my default IP address only on startup
 [ip]
-command=hostname --all-ip-addresses | awk '{ print "IP:" $1 }'
+command=hostname --ip-address | awk '{ print "IP:" $1 }'
 interval=once
 color=#91E78B
 

--- a/docs/README.adoc
+++ b/docs/README.adoc
@@ -30,7 +30,7 @@ color=#A4C2F4
 
 # Query my default IP address only on startup
 [ip]
-command=hostname --ip-address | awk '{ print "IP:" $1 }'
+command=hostname -i | awk '{ print "IP:" $1 }'
 interval=once
 color=#91E78B
 

--- a/docs/README.adoc
+++ b/docs/README.adoc
@@ -30,7 +30,7 @@ color=#A4C2F4
 
 # Query my default IP address only on startup
 [ip]
-command=hostname --ip-addresses | awk '{ print "IP:" $1 }'
+command=hostname --all-ip-addresses | awk '{ print "IP:" $1 }'
 interval=once
 color=#91E78B
 


### PR DESCRIPTION
Hi,
This is just a small fix for a typo on `hostname` option for one of the README.md example.
Thanks for maintaining `i3blocks`!