### PR TITLE
Accept EOF as well as newline to complete line read

### DIFF
--- a/line.c
+++ b/line.c
@@ -37,8 +37,13 @@ static ssize_t line_gets(int fd, char *buf, size_t size)
 			return -ENOSPC;
 
 		err = line_getc(fd, buf + len);
-		if (err)
+		if (err) {
+			if (err == -EAGAIN && len > 0) {
+				len++;
+				break;
+			}
 			return err;
+		}
 
 		if (buf[len++] == '\n')
 			break;


### PR DESCRIPTION
Addresses #393 and #403.

Currently a line isn't read if any error is reached, including EAGAIN,
which indicates you've reached the end of a file descriptor.

This commit allows EAGAIN to terminate a line if anything else has been
read from that fd. If nothing else has been read, it's either
non-existent or empty, which makes sense to error instead.