### PR TITLE
Style support for status bar

### DIFF
--- a/i3bar.c
+++ b/i3bar.c
@@ -23,6 +23,7 @@
 #include "log.h"
 #include "map.h"
 #include "term.h"
+#include <stdlib.h>
 
 /* See https://i3wm.org/docs/i3bar-protocol.html for details */
 
@@ -148,6 +149,78 @@ static int i3bar_print_pair(const char *key, const char *value, void *data)
 	return 0;
 }
 
+static const char* i3bar_get_value_by_ref(const char *value, struct block *block)
+{
+	if(value == NULL || block == NULL)
+		return NULL;
+
+	if(value[0] == '#')	// color
+	{
+		return value;
+	}
+	if(value[0] == '&')	// reference
+	{
+		const char *ref = map_get(block->env, value + 1);
+		if(ref != NULL)
+		{
+			// reccursive reference lookup
+			return i3bar_get_value_by_ref(ref, block);
+		}
+		else
+		{
+			block_debug(block, "Cannot found reference %s.", value);
+			return value;
+		}
+	}
+
+	return value;
+}
+
+static int i3bar_parse_pattern(struct block *block, const char *pattern, char *res)
+{
+	char pattern_copy[BUFSIZ] = {0};
+
+	// TODO: parametrize wia block->conf
+	char delim[] = "%";
+
+	// copy, because strtok modifies input string
+	// TODO: use strdup
+	strcpy(pattern_copy, pattern);
+
+	char *ptr = strtok(pattern_copy, delim);
+	bool token = false;
+	while(ptr != NULL)
+	{
+		if(token)
+		{
+			const char *value = map_get(block->env, ptr);
+			if(value != NULL)
+			{
+				const char *final_value = i3bar_get_value_by_ref(value, block);
+				if(final_value)
+					strcat(res, final_value);
+				else
+				{
+					block_error(block, "Something wrong with %s",  value);	// should not hit there
+					return 2;
+				}
+			}
+			else
+			{
+				block_debug(block, "Key %s is not defined.", ptr);
+				return 1;
+			}
+		}
+		else
+			strcat(res, ptr);
+
+		token = !token;
+		ptr = strtok(NULL, delim);
+	}
+
+	return 0;
+}
+
 static int i3bar_print_block(struct block *block, void *data)
 {
 	const char *full_text = map_get(block->env, "full_text");
@@ -161,12 +234,33 @@ static int i3bar_print_block(struct block *block, void *data)
 		return 0;
 	}
 
+	char *full_text_copy = NULL;
+
+	const char *full_text_pattern = map_get(block->config, "full_text_pattern");
+	if(full_text_pattern)
+	{
+		char buf[BUFSIZ] = {0};
+
+		if(i3bar_parse_pattern(block, full_text_pattern, buf) == 0)
+		{
+			full_text_copy = strdup(full_text);
+			if(full_text_copy != NULL)
+				map_set(block->env, "full_text", buf);
+		}
+	}
+
 	if ((*mcount)++)
 		fprintf(stdout, ",");
 
 	fprintf(stdout, "{");
 	err = map_for_each(block->env, i3bar_print_pair, &pcount);
 	fprintf(stdout, "}");
+
+	if(full_text_copy)
+	{
+		map_set(block->env, "full_text", full_text_copy);
+		free(full_text_copy);
+	}
 
 	return err;
 }


### PR DESCRIPTION
With this PR you can make statusbar output looks like e.g. powerline.
Example there: https://i.redd.it/13a2zz2ifjw31.png

New field in config: full_text_pattern
Value of this pattern will be parsed and all values surrounded by '%' will be used as parameter keys.
Values started with '&' - are references on another parameter keys.

Demo config example:
```
command=~/.config/i3/i3blocksScripts/$BLOCK_NAME
separator_block_width=0
markup=pango
color1=#ffffffa0
color2=#000000a0
background=#000000a0
separator_glyph=
full_text_pattern=<span foreground='%gfg%' background='%gbg%'>%separator_glyph%</span><span foreground='%fg%' background='%bg%'>%full_text%</span>
gbg=&fg
gfg=&bg

[foo]
command=echo foo
bg=&color1
fg=&color2
interval=once

[bar]
command=echo bar
bg=&color2
fg=&color1
interval=once
```

i3 config:
```
bar {
    position top
    i3bar_command i3bar -t 0.1
    colors{
        background #000000a0
    }

    status_command i3blocks -c demo.conf
}
```