### PR TITLE
Allow hiding/unhiding the bar with SIGUSR1/2

### DIFF
--- a/bar.c
+++ b/bar.c
@@ -182,6 +182,16 @@ static void bar_poll_readable(struct bar *bar, const int fd)
 	}
 }
 
+static void bar_hide(struct bar *bar) {
+	bar->hidden = true;
+	bar_print(bar);
+}
+
+static void bar_unhide(struct bar *bar) {
+	bar->hidden = false;
+	bar_print(bar);
+}
+
 static int gcd(int a, int b)
 {
 	while (b != 0)
@@ -239,7 +249,7 @@ static int bar_setup(struct bar *bar)
 	if (err)
 		return err;
 
-	/* Deprecated signals */
+	/* Hide/unhide */
 	err = sys_sigaddset(set, SIGUSR1);
 	if (err)
 		return err;
@@ -380,9 +390,12 @@ static int bar_poll(struct bar *bar)
 			continue;
 		}
 
-		if (sig == SIGUSR1 || sig == SIGUSR2) {
-			error("SIGUSR{1,2} are deprecated, ignoring.");
-			continue;
+		if (sig == SIGUSR1) {
+			bar_hide(bar);
+		}
+
+		if (sig == SIGUSR2) {
+			bar_unhide(bar);
 		}
 
 		debug("unhandled signal %d", sig);

--- a/bar.c
+++ b/bar.c
@@ -392,10 +392,12 @@ static int bar_poll(struct bar *bar)
 
 		if (sig == SIGUSR1) {
 			bar_hide(bar);
+			continue;
 		}
 
 		if (sig == SIGUSR2) {
 			bar_unhide(bar);
+			continue;
 		}
 
 		debug("unhandled signal %d", sig);

--- a/bar.h
+++ b/bar.h
@@ -28,6 +28,7 @@ struct bar {
 	struct block *blocks;
 	sigset_t sigset;
 	bool term;
+	bool hidden;
 };
 
 #define bar_printf(bar, lvl, fmt, ...) \

--- a/i3bar.c
+++ b/i3bar.c
@@ -165,9 +165,7 @@ static int i3bar_print_block(struct block *block, void *data)
 		fprintf(stdout, ",");
 
 	fprintf(stdout, "{");
-	if (!block->bar->hidden) {
-		err = map_for_each(block->env, i3bar_print_pair, &pcount);
-	}
+	err = map_for_each(block->env, i3bar_print_pair, &pcount);
 	fprintf(stdout, "}");
 
 	return err;
@@ -177,7 +175,7 @@ static int i3bar_print_block(struct block *block, void *data)
 {
 	struct block *block = bar->blocks;
 	unsigned int mcount = 0;
-	int err;
+	int err = 0;
 
 	if (bar->term) {
 		i3bar_print_term(bar);
@@ -185,12 +183,14 @@ static int i3bar_print_block(struct block *block, void *data)
 	}
 
 	fprintf(stdout, ",[");
-	while (block) {
-		err = i3bar_print_block(block, &mcount);
-		if (err)
-			break;
+	if (!block->bar->hidden) {
+		while (block) {
+			err = i3bar_print_block(block, &mcount);
+			if (err)
+				break;
 
-		block = block->next;
+			block = block->next;
+		}
 	}
 	fprintf(stdout, "]\n");
 	fflush(stdout);

--- a/i3bar.c
+++ b/i3bar.c
@@ -165,7 +165,9 @@ static int i3bar_print_block(struct block *block, void *data)
 		fprintf(stdout, ",");
 
 	fprintf(stdout, "{");
-	err = map_for_each(block->env, i3bar_print_pair, &pcount);
+	if (!block->bar->hidden) {
+		err = map_for_each(block->env, i3bar_print_pair, &pcount);
+	}
 	fprintf(stdout, "}");
 
 	return err;


### PR DESCRIPTION
I'm not sure if this is something you'd actually want to upstream, but I'm posting it for consideration. This allows you to hide all blocks on the bar with SIGUSR1 and restore them with SIGUSR2. It doesn't actually prevent the blocks from updating, so there's no stale information when they are unhidden.

My usecase is temporarily making swaybar invisible without changing its height, so I can draw a transparent bemenu into the space. When bemenu closes, I restore the contents of the bar.

The rationale for splitting hide/show into separate signals is to allow an external script to do state tracking if necessary. If the hidden state was instead toggled with a single signal, you risk it getting out of sync with the calling script.