### PR TITLE
Add enableif property

### DIFF
--- a/bar.c
+++ b/bar.c
@@ -435,10 +435,34 @@ static struct bar *bar_create(bool term)
 	return bar;
 }
 
+static int bar_check_block_enabled(const char* command)
+{
+  int result;
+
+  result = system(command);
+
+  if (result == 0)
+  {
+    return 1;
+  }
+
+  return 0;
+}
+
 static int bar_config_cb(struct map *map, void *data)
 {
 	struct bar *bar = data;
 	struct block *block = bar->blocks;
+
+  const char* enableif_command = map_get(map, "enableif");
+  if (enableif_command)
+  {
+    if (!bar_check_block_enabled(enableif_command))
+    {
+      map_destroy(map);
+      return 0;
+    }
+  }
 
 	while (block->next)
 		block = block->next;


### PR DESCRIPTION
Hi,

first of all, thank you for making i3blocks. 
I want to share my configuration between my laptop and my desktop computer. On my laptop I want the bar to display different informations than on my desktop bar. For example, on my laptop, I want information about the battery, and on my desktop, I don't want this information.

My pull request adds a `enableif` property to the blocks. In this `enableif` property, the user can execute any command. If the command is successful, the block will be activated. If the command was not successful, the block will not be activated.

Please tell me if such functionality makes sense or if there are better ways to achieve the same. If it is the right way, I would be happy to hear how I can improve the patch.