### PR TITLE
block: Keep RTMIN through RTMAX signals blocked in child

### DIFF
--- a/block.c
+++ b/block.c
@@ -234,11 +234,15 @@ static int block_child_sig(struct block *block)
 {
 	sigset_t set;
 	int err;
+	unsigned int i;
 
 	/* It'd be safe to assume that all signals are unblocked by default */
 	err = sys_sigfillset(&set);
 	if (err)
 		return err;
+
+	for (i = 0; i <= SIGRTMAX - SIGRTMIN; i++)
+		sys_sigdelset(&set, SIGRTMIN + i);
 
 	return sys_sigunblock(&set);
 }

--- a/sys.c
+++ b/sys.c
@@ -203,6 +203,20 @@ int sys_sigaddset(sigset_t *set, int sig)
 	return 0;
 }
 
+int sys_sigdelset(sigset_t *set, int sig)
+{
+	int rc;
+
+	rc = sigdelset(set, sig);
+	if (rc == -1) {
+		sys_errno("sigdelset(%d (%s))", sig, strsignal(sig));
+		rc = -errno;
+		return rc;
+	}
+
+	return 0;
+}
+
 static int sys_sigprocmask(const sigset_t *set, int how)
 {
 	int rc;

--- a/sys.h
+++ b/sys.h
@@ -38,6 +38,7 @@ const char *sys_getenv(const char *name);
 int sys_sigemptyset(sigset_t *set);
 int sys_sigfillset(sigset_t *set);
 int sys_sigaddset(sigset_t *set, int sig);
+int sys_sigdelset(sigset_t *set, int sig);
 int sys_sigunblock(const sigset_t *set);
 int sys_sigsetmask(const sigset_t *set);
 int sys_sigwaitinfo(sigset_t *set, int *sig, int *fd);


### PR DESCRIPTION
When a child process is forked for a block, it has the signals RTMIN
through RTMAX blocked by default, but block_child_sig() unblocks all
signals including these.

Unblocking these signals is troublesome given that:
- The easiest way to signal i3blocks for an update is through pkill (as
  shown at https://vivien.github.io/i3blocks/#_signal ). But pkill sends
  a signal to all processes with that name, which includes the child
  fork.
- Since those signals are unblocked, but not handled, in the child, when
  one of them is sent to i3blocks, and while it is being handled in
  the child process, another one is sent, the child process will also
  receive the signal and therefore crash since it is unhandled.

If we assume that the RTMIN through RTMAX signals are uncommon enough
that they won't be used in the child process, the solution is as easy as
keeping these signals blocked for the child process.

Fixes #455.