### PR TITLE
Link output format section in command section docs

### DIFF
--- a/docs/README.adoc
+++ b/docs/README.adoc
@@ -165,9 +165,11 @@ These will be considered as simple variables at runtime.
 
 === command
 
-The optional _command_ property specifies a command line to be executed with `sh -c`.
-The command can be relative to the configuration file where it is defined.
-If the command outputs some text, it is used to update the block.
+The optional _command_ property specifies a command line to be executed with
+`sh -c`. The command can be relative to the configuration file where it is
+defined. If the command outputs some text, it is used to update the block. See
+the link:./#format[format section] for more information about expected text
+output.
 
 An exit code of 0 means success.
 A special exit code of _33_ will set the _urgent_ i3bar key to true.


### PR DESCRIPTION
I was re-reading the docs for a command's output today and I was surprised that the paragraph for the `command` parameter didn't mention the `format` section. This should make the docs a bit more comprehensive for others by adding a sentence linking to the relevant section.