### PR TITLE
ticker: Initial support. Closes #466

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@ config.status
 configure
 i3blocks-config.h*
 stamp-h1
-
+cscope.out

--- a/Makefile.am
+++ b/Makefile.am
@@ -2,6 +2,14 @@ DEFS += \
 	-DSYSCONFDIR=\"$(sysconfdir)\"
 
 bin_PROGRAMS = i3blocks
+
+i3blocks_CFLAGS = \
+	$(AM_CFLAGS) \
+	$(UTF8PROC_CFLAGS)
+
+i3blocks_LDADD = \
+	$(UTF8PROC_LIBS)
+
 i3blocks_SOURCES = \
 	bar.c \
 	bar.h \
@@ -22,7 +30,9 @@ i3blocks_SOURCES = \
 	map.h \
 	sys.c \
 	sys.h \
-	term.h
+	term.h \
+	ticker.c \
+	ticker.h
 
 dist_man1_MANS = \
 	docs/i3blocks.1

--- a/bar.c
+++ b/bar.c
@@ -1,6 +1,6 @@
 /*
  * bar.c - status line handling functions
- * Copyright (C) 2014-2019  Vivien Didelot
+ * Copyright (C) 2014-2023  Vivien Didelot, Bogdan Migunov
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -113,7 +113,8 @@ static void bar_poll_expired(struct bar *bar)
 			if (((long) (next_update - now)) <= 0) {
 				block_debug(block, "ticker expired");
 
-				if (block->interval == 0 || block->interval == INTERVAL_ONCE)
+				if (block->interval == 0 || block->interval == INTERVAL_ONCE ||
+						block->interval > block->ticker->interval)
 					block_set_full_text_saved(block);
 
 				bar_print(bar);

--- a/block.c
+++ b/block.c
@@ -129,7 +129,8 @@ static int block_stdout(struct block *block)
 		if (block->ticker && block->format == FORMAT_RAW) {
 			ticker_output = ticker_output_get(block->ticker, full_text);
 
-			if (block->interval == 0 || block->interval == INTERVAL_ONCE) {
+			if (block->interval == 0 || block->interval == INTERVAL_ONCE ||
+					block->interval > block->ticker->interval) {
 				free(block->ticker->full_text_saved);
 				free(block->ticker->label_saved);
 

--- a/block.c
+++ b/block.c
@@ -19,6 +19,8 @@
 #include <ctype.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdio.h>
+#include <stdbool.h>
 
 #include "bar.h"
 #include "block.h"
@@ -26,6 +28,7 @@
 #include "line.h"
 #include "log.h"
 #include "sys.h"
+#include "ticker.h"
 
 const char *block_get(const struct block *block, const char *key)
 {
@@ -113,8 +116,35 @@ static int block_stdout(struct block *block)
 	/* Deprecated label */
 	label = block_get(block, "label");
 	full_text = block_get(block, "full_text");
-	if (label && full_text) {
-		snprintf(buf, sizeof(buf), "%s%s", label, full_text);
+
+	memset(buf, '\0', BUFSIZ);
+
+	if (full_text && (label || block->ticker)) {
+		char *ticker_output = NULL;
+		size_t label_strlen = 0;
+
+		if (label)
+			label_strlen = snprintf(buf, sizeof(buf), "%s", label);
+
+		if (block->ticker && block->format == FORMAT_RAW) {
+			ticker_output = ticker_output_get(block->ticker, full_text);
+
+			if (block->interval == 0 || block->interval == INTERVAL_ONCE) {
+				free(block->ticker->full_text_saved);
+				free(block->ticker->label_saved);
+
+				block->ticker->full_text_saved = strdup(full_text);
+				if (label)
+					block->ticker->label_saved = strdup(label);
+			}
+		}
+
+		if (ticker_output) {
+			strncat(buf, ticker_output, BUFSIZ - label_strlen);
+			free(ticker_output);
+		} else
+			strncat(buf, full_text, BUFSIZ - label_strlen);
+
 		err = block_set(block, "full_text", buf);
 		if (err)
 			return err;
@@ -146,6 +176,36 @@ int block_update(struct block *block)
 	block_debug(block, "updated successfully");
 
 	return 0;
+}
+
+void block_set_full_text_saved(struct block *block)
+{
+	char buf[BUFSIZ];
+
+	memset(buf, '\0', BUFSIZ);
+
+	if (block->ticker && block->ticker->full_text_saved) {
+		size_t label_strlen = 0;
+		char *ticker_output = NULL;
+
+		if (block->ticker->label_saved)
+			label_strlen = snprintf(buf, sizeof(buf), "%s",
+					block->ticker->label_saved);
+
+		if (block->ticker && block->format == FORMAT_RAW)
+			ticker_output = ticker_output_get(block->ticker,
+					block->ticker->full_text_saved);
+
+		if (ticker_output) {
+			strncat(buf, ticker_output, BUFSIZ - label_strlen);
+			free(ticker_output);
+		} else
+			strncat(buf, block->ticker->full_text_saved, BUFSIZ - label_strlen);
+	}
+
+	block_set(block, "full_text", buf);
+
+	return;
 }
 
 static int block_send_key(const char *key, const char *value, void *data)
@@ -510,6 +570,39 @@ static int i3blocks_setup(struct block *block)
 	else
 		block->signal = atoi(value);
 
+	value = map_get(block->config, TICKER_CONFIG_OPTION);
+	if (value && strcmp(value, "true") == 0)
+		block->ticker = ticker_create();
+
+	if (block->ticker) {
+		value = map_get(block->config, TICKER_CONFIG_OPTION_DELIMETER);
+		if (!value || (ticker_delimeter_set(block->ticker, value)
+				!= TICKER_RESULT_SUCCESS)) {
+			debug("Failed to set ticker delimeter. Setting default delimeter");
+			block->ticker->delimeter = TICKER_DELIMETER_DEFAULT;
+		}
+
+		value = map_get(block->config, TICKER_CONFIG_OPTION_DIRECTION);
+		if (value && (strcmp(value, "left") == 0 || strcmp(value, "l") == 0))
+			block->ticker->direction = TICKER_DIRECTION_LEFT;
+		else if (value && (strcmp(value, "right") == 0 || strcmp(value, "r") == 0))
+			block->ticker->direction = TICKER_DIRECTION_RIGHT;
+		else
+			block->ticker->direction = TICKER_DIRECTION_DEFAULT;
+
+		value = map_get(block->config, TICKER_CONFIG_OPTION_CHARS_LIMIT);
+		if (value && (atoi(value) > 0))
+			block->ticker->chars_limit = atoi(value);
+		else
+			block->ticker->chars_limit = TICKER_CHARS_LIMIT_DEFAULT;
+
+		value = map_get(block->config, TICKER_CONFIG_OPTION_INTERVAL);
+		if (value && (atoi(value) > 0))
+			block->ticker->interval = atoi(value);
+		else
+			block->ticker->interval = TICKER_INTERVAL_DEFAULT;
+	}
+
 	return 0;
 }
 
@@ -536,9 +629,12 @@ int block_setup(struct block *block)
 
 void block_destroy(struct block *block)
 {
+	debug("block_destroy");
 	map_destroy(block->config);
 	map_destroy(block->env);
 	free(block->name);
+	if (block->ticker)
+		ticker_destroy(block->ticker);
 	free(block);
 }
 
@@ -550,6 +646,8 @@ struct block *block_create(struct bar *bar, const struct map *config)
 	block = calloc(1, sizeof(struct block));
 	if (!block)
 		return NULL;
+
+	block->ticker = NULL;
 
 	block->bar = bar;
 

--- a/block.h
+++ b/block.h
@@ -20,10 +20,12 @@
 #define BLOCK_H
 
 #include <sys/types.h>
+#include <stdbool.h>
 
 #include "bar.h"
 #include "log.h"
 #include "map.h"
+#include "ticker.h"
 
 #define INTERVAL_ONCE		-1
 #define INTERVAL_REPEAT		-2
@@ -59,6 +61,8 @@ struct block {
 	int out[2];
 	int code;
 	pid_t pid;
+
+	struct ticker *ticker;
 
 	struct block *next;
 };
@@ -107,6 +111,7 @@ int block_spawn(struct block *block);
 void block_touch(struct block *block);
 int block_reap(struct block *block);
 int block_update(struct block *block);
+void block_set_full_text_saved(struct block *block);
 void block_close(struct block *block);
 
 #endif /* BLOCK_H */

--- a/block.h
+++ b/block.h
@@ -1,6 +1,6 @@
 /*
  * block.h - definition of a block
- * Copyright (C) 2014-2019  Vivien Didelot
+ * Copyright (C) 2014-2023  Vivien Didelot, Bogdan Migunov
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/configure.ac
+++ b/configure.ac
@@ -7,6 +7,7 @@ PKG_CHECK_MODULES([BASH_COMPLETION], [bash-completion >= 2.0],
   [BASH_COMPLETION_DIR="$(pkg-config --variable=completionsdir bash-completion)"],
   [BASH_COMPLETION_DIR="$datadir/bash-completion/completions"]
 )
+PKG_CHECK_MODULES([UTF8PROC], [libutf8proc])
 AC_SUBST([BASH_COMPLETION_DIR])
 AM_CONDITIONAL([ENABLE_BASH_COMPLETION],[test "xBASH_COMPLETION_DIR" != "x"])
 AC_CONFIG_FILES([

--- a/docs/README.adoc
+++ b/docs/README.adoc
@@ -63,6 +63,16 @@ make
 make install
 ----
 
+=== Dependencies
+
+Since ticker feature has been introduced, there is only one package (link:https://github.com/JuliaStrings/utf8proc[libutf8proc]) which is need to be installed. On Debian-based systems it can be obtained via apt:
+
+[source]
+----
+sudo apt-get install libutf8proc-dev
+----
+
+
 == Getting started
 
 In your i3 configuration file, define {progname} as the link:https://i3wm.org/docs/userguide.html#status_command[status line command] of a new bar block:
@@ -315,6 +325,43 @@ command=printf '{"full_text":"Counter: %s", "_count":%d}\n' $_count $((_count + 
 format=json
 interval=1
 ----
+
+
+=== ticker
+
+Optional property. Enable or disable ticker feature. Valid values are `true` & `false`.
+This feature only works with the raw format. It will scroll output string char by char with given interval. Offset zeroes if there are changes in the output string.
+Default value is `false`.
+
+[source,ini]
+----
+#Output string differs every minute
+[ticker_test]
+command=echo 'TEST_STRING-'$(date +%M)
+interval=1
+ticker=true
+ticker_interval=2
+----
+
+==== ticker_delimeter
+
+Optional property (use in conjunction with _ticker_). Delimeter character which separates beginning & ending of the output string. If value is set to a string containing multiple characters, only the first character will be used as the delimeter.
+Default value is `|`.
+
+==== ticker_direction
+
+Direction of the ticker. Valid values are `right` (shortcut `r`) & `left` (shortcut `l`).
+Default value is `left`.
+
+==== ticker_chars_limit
+
+Limit of the characters to be displayed if _ticker_ is enabled. `0` or negative values set limit to default value.
+Default value is `16`.
+
+==== ticker_interval
+
+Optional property. Defines interval of time after which the output string is shifted by a single char.
+Default value is `1`.
 
 == Click
 

--- a/docs/blocklets.html
+++ b/docs/blocklets.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 2.0.10">
+<meta name="generator" content="Asciidoctor 2.0.12">
 <title>Blocklets</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
@@ -47,7 +47,7 @@ textarea{overflow:auto;vertical-align:top}
 table{border-collapse:collapse;border-spacing:0}
 *,*::before,*::after{-moz-box-sizing:border-box;-webkit-box-sizing:border-box;box-sizing:border-box}
 html,body{font-size:100%}
-body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;font-weight:400;font-style:normal;line-height:1;position:relative;cursor:auto;tab-size:4;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
+body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;font-weight:400;font-style:normal;line-height:1;position:relative;cursor:auto;tab-size:4;word-wrap:anywhere;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
 a:hover{cursor:pointer}
 img,object,embed{max-width:100%;height:auto}
 object,embed{height:100%}
@@ -62,10 +62,8 @@ img{-ms-interpolation-mode:bicubic}
 img,object,svg{display:inline-block;vertical-align:middle}
 textarea{height:auto;min-height:50px}
 select{width:100%}
-.center{margin-left:auto;margin-right:auto}
-.stretch{width:100%}
 .subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#7a2518;font-weight:400;margin-top:0;margin-bottom:.25em}
-div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0;direction:ltr}
+div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0}
 a{color:#2156a5;text-decoration:underline;line-height:inherit}
 a:hover,a:focus{color:#1d4b8f}
 a img{border:0}
@@ -105,19 +103,22 @@ h1{font-size:2.75em}
 h2{font-size:2.3125em}
 h3,#toctitle,.sidebarblock>.content>.title{font-size:1.6875em}
 h4{font-size:1.4375em}}
-table{background:#fff;margin-bottom:1.25em;border:solid 1px #dedede}
+table{background:#fff;margin-bottom:1.25em;border:solid 1px #dedede;word-wrap:normal}
 table thead,table tfoot{background:#f7f8f7}
 table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
 table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
 table tr.even,table tr.alt{background:#f8f8f7}
-table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{display:table-cell;line-height:1.6}
+table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{line-height:1.6}
 h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
 h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
+.center{margin-left:auto;margin-right:auto}
+.stretch{width:100%}
 .clearfix::before,.clearfix::after,.float-group::before,.float-group::after{content:" ";display:table}
 .clearfix::after,.float-group::after{clear:both}
-:not(pre):not([class^=L])>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background:#f7f7f8;-webkit-border-radius:4px;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed;word-wrap:break-word}
-:not(pre)>code.nobreak{word-wrap:normal}
-:not(pre)>code.nowrap{white-space:nowrap}
+:not(pre).nobreak{word-wrap:normal}
+:not(pre).nowrap{white-space:nowrap}
+:not(pre).pre-wrap{white-space:pre-wrap}
+:not(pre):not([class^=L])>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background:#f7f7f8;-webkit-border-radius:4px;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed}
 pre{color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;line-height:1.45;text-rendering:optimizeSpeed}
 pre code,pre pre{color:inherit;font-size:inherit;line-height:inherit}
 pre>code{display:block}
@@ -182,7 +183,7 @@ body.toc2.toc-right{padding-left:0;padding-right:20em}}
 #content #toc{border-style:solid;border-width:1px;border-color:#e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;-webkit-border-radius:4px;border-radius:4px}
 #content #toc>:first-child{margin-top:0}
 #content #toc>:last-child{margin-bottom:0}
-#footer{max-width:100%;background:rgba(0,0,0,.8);padding:1.25em}
+#footer{max-width:none;background:rgba(0,0,0,.8);padding:1.25em}
 #footer-text{color:rgba(255,255,255,.8);line-height:1.44}
 #content{margin-bottom:.625em}
 .sect1{padding-bottom:.625em}
@@ -205,7 +206,7 @@ table.tableblock #preamble>.sectionbody>[class="paragraph"]:first-of-type p{font
 .admonitionblock>table td.icon{text-align:center;width:80px}
 .admonitionblock>table td.icon img{max-width:none}
 .admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
-.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #dddddf;color:rgba(0,0,0,.6)}
+.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #dddddf;color:rgba(0,0,0,.6);word-wrap:anywhere}
 .admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
 .exampleblock>.content{border-style:solid;border-width:1px;border-color:#e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;-webkit-border-radius:4px;border-radius:4px}
 .exampleblock>.content>:first-child{margin-top:0}
@@ -215,7 +216,7 @@ table.tableblock #preamble>.sectionbody>[class="paragraph"]:first-of-type p{font
 .sidebarblock>:last-child{margin-bottom:0}
 .sidebarblock>.content>.title{color:#7a2518;margin-top:0;text-align:center}
 .exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
-.literalblock pre,.listingblock>.content>pre{-webkit-border-radius:4px;border-radius:4px;word-wrap:break-word;overflow-x:auto;padding:1em;font-size:.8125em}
+.literalblock pre,.listingblock>.content>pre{-webkit-border-radius:4px;border-radius:4px;overflow-x:auto;padding:1em;font-size:.8125em}
 @media screen and (min-width:768px){.literalblock pre,.listingblock>.content>pre{font-size:.90625em}}
 @media screen and (min-width:1280px){.literalblock pre,.listingblock>.content>pre{font-size:1em}}
 .literalblock pre,.listingblock>.content>pre:not(.highlight),.listingblock>.content>pre[class="highlight"],.listingblock>.content>pre[class^="highlight "]{background:#f7f7f8}
@@ -261,21 +262,20 @@ pre.pygments .lineno::before{content:"";margin-right:-.125em}
 .quoteblock.excerpt,.quoteblock .quoteblock{margin-left:0}
 .quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{color:inherit;font-size:1.0625rem}
 .quoteblock.excerpt .attribution,.quoteblock .quoteblock .attribution{color:inherit;text-align:left;margin-right:0}
-table.tableblock{max-width:100%;border-collapse:separate}
 p.tableblock:last-child{margin-bottom:0}
+td.tableblock>.content{margin-bottom:1.25em;word-wrap:anywhere}
 td.tableblock>.content>:last-child{margin-bottom:-1.25em}
-td.tableblock>.content>:last-child.sidebarblock{margin-bottom:0}
 table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
-table.grid-all>thead>tr>.tableblock,table.grid-all>tbody>tr>.tableblock{border-width:0 1px 1px 0}
-table.grid-all>tfoot>tr>.tableblock{border-width:1px 1px 0 0}
-table.grid-cols>*>tr>.tableblock{border-width:0 1px 0 0}
-table.grid-rows>thead>tr>.tableblock,table.grid-rows>tbody>tr>.tableblock{border-width:0 0 1px}
-table.grid-rows>tfoot>tr>.tableblock{border-width:1px 0 0}
-table.grid-all>*>tr>.tableblock:last-child,table.grid-cols>*>tr>.tableblock:last-child{border-right-width:0}
-table.grid-all>tbody>tr:last-child>.tableblock,table.grid-all>thead:last-child>tr>.tableblock,table.grid-rows>tbody>tr:last-child>.tableblock,table.grid-rows>thead:last-child>tr>.tableblock{border-bottom-width:0}
+table.grid-all>*>tr>*{border-width:1px}
+table.grid-cols>*>tr>*{border-width:0 1px}
+table.grid-rows>*>tr>*{border-width:1px 0}
 table.frame-all{border-width:1px}
+table.frame-ends{border-width:1px 0}
 table.frame-sides{border-width:0 1px}
-table.frame-topbot,table.frame-ends{border-width:1px 0}
+table.frame-none>colgroup+*>:first-child>*,table.frame-sides>colgroup+*>:first-child>*{border-top-width:0}
+table.frame-none>:last-child>:last-child>*,table.frame-sides>:last-child>:last-child>*{border-bottom-width:0}
+table.frame-none>*>tr>:first-child,table.frame-ends>*>tr>:first-child{border-left-width:0}
+table.frame-none>*>tr>:last-child,table.frame-ends>*>tr>:last-child{border-right-width:0}
 table.stripes-all tr,table.stripes-odd tr:nth-of-type(odd),table.stripes-even tr:nth-of-type(even),table.stripes-hover tr:hover{background:#f8f8f7}
 th.halign-left,td.halign-left{text-align:left}
 th.halign-right,td.halign-right{text-align:right}
@@ -284,7 +284,7 @@ th.valign-top,td.valign-top{vertical-align:top}
 th.valign-bottom,td.valign-bottom{vertical-align:bottom}
 th.valign-middle,td.valign-middle{vertical-align:middle}
 table thead th,table tfoot th{font-weight:bold}
-tbody tr th{display:table-cell;line-height:1.6;background:#f7f8f7}
+tbody tr th{background:#f7f8f7}
 tbody tr th,tbody tr th p,tfoot tr th,tfoot tr th p{color:rgba(0,0,0,.8);font-weight:bold}
 p.tableblock>code:only-child{background:none;padding:0}
 p.tableblock{font-size:1em}
@@ -313,6 +313,7 @@ ol.lowergreek{list-style-type:lower-greek}
 .hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
 td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
 td.hdlist1{font-weight:bold;padding-bottom:1.25em}
+td.hdlist2{word-wrap:anywhere}
 .literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
 .colist td:not([class]):first-child{padding:.4em .75em 0;line-height:1;vertical-align:top}
 .colist td:not([class]):first-child img{max-width:none}
@@ -385,7 +386,7 @@ a span.icon>.fa{cursor:inherit}
 .admonitionblock td.icon .icon-warning::before{content:"\f071";color:#bf6900}
 .admonitionblock td.icon .icon-caution::before{content:"\f06d";color:#bf3400}
 .admonitionblock td.icon .icon-important::before{content:"\f06a";color:#bf0000}
-.conum[data-value]{display:inline-block;color:#fff!important;background:rgba(0,0,0,.8);-webkit-border-radius:100px;border-radius:100px;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
+.conum[data-value]{display:inline-block;color:#fff!important;background:rgba(0,0,0,.8);-webkit-border-radius:50%;border-radius:50%;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
 .conum[data-value] *{color:#fff!important}
 .conum[data-value]+b{display:none}
 .conum[data-value]::after{content:attr(data-value)}
@@ -412,6 +413,7 @@ thead{display:table-header-group}
 svg{max-width:100%}
 p,blockquote,dt,td.content{font-size:1em;orphans:3;widows:3}
 h2,h3,#toctitle,.sidebarblock>.content>.title{page-break-after:avoid}
+#header,#content,#footnotes,#footer{max-width:none}
 #toc,.sidebarblock,.exampleblock>.content{background:none!important}
 #toc{border-bottom:1px solid #dddddf!important;padding-bottom:0!important}
 body.book #header{text-align:center}

--- a/docs/i3blocks.1
+++ b/docs/i3blocks.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: i3blocks
 .\"    Author: [see the "AUTHOR(S)" section]
-.\" Generator: Asciidoctor 2.0.10
-.\"      Date: 2019-08-12
+.\" Generator: Asciidoctor 2.0.12
+.\"      Date: 2021-11-23
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "I3BLOCKS" "1" "2019-08-12" "\ \&" "\ \&"
+.TH "I3BLOCKS" "1" "2021-11-23" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0
@@ -62,9 +62,11 @@ i3blocks must be defined as the status line command of the \fBbar\fP block descr
 .sp
 .if n .RS 4
 .nf
+.fam C
 bar {
   status_command i3blocks
 }
+.fam
 .fi
 .if n .RE
 .sp

--- a/docs/i3blocks.1.html
+++ b/docs/i3blocks.1.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 2.0.10">
+<meta name="generator" content="Asciidoctor 2.0.12">
 <title>i3blocks(1)</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
@@ -47,7 +47,7 @@ textarea{overflow:auto;vertical-align:top}
 table{border-collapse:collapse;border-spacing:0}
 *,*::before,*::after{-moz-box-sizing:border-box;-webkit-box-sizing:border-box;box-sizing:border-box}
 html,body{font-size:100%}
-body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;font-weight:400;font-style:normal;line-height:1;position:relative;cursor:auto;tab-size:4;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
+body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;font-weight:400;font-style:normal;line-height:1;position:relative;cursor:auto;tab-size:4;word-wrap:anywhere;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
 a:hover{cursor:pointer}
 img,object,embed{max-width:100%;height:auto}
 object,embed{height:100%}
@@ -62,10 +62,8 @@ img{-ms-interpolation-mode:bicubic}
 img,object,svg{display:inline-block;vertical-align:middle}
 textarea{height:auto;min-height:50px}
 select{width:100%}
-.center{margin-left:auto;margin-right:auto}
-.stretch{width:100%}
 .subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#7a2518;font-weight:400;margin-top:0;margin-bottom:.25em}
-div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0;direction:ltr}
+div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0}
 a{color:#2156a5;text-decoration:underline;line-height:inherit}
 a:hover,a:focus{color:#1d4b8f}
 a img{border:0}
@@ -105,19 +103,22 @@ h1{font-size:2.75em}
 h2{font-size:2.3125em}
 h3,#toctitle,.sidebarblock>.content>.title{font-size:1.6875em}
 h4{font-size:1.4375em}}
-table{background:#fff;margin-bottom:1.25em;border:solid 1px #dedede}
+table{background:#fff;margin-bottom:1.25em;border:solid 1px #dedede;word-wrap:normal}
 table thead,table tfoot{background:#f7f8f7}
 table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
 table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
 table tr.even,table tr.alt{background:#f8f8f7}
-table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{display:table-cell;line-height:1.6}
+table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{line-height:1.6}
 h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
 h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
+.center{margin-left:auto;margin-right:auto}
+.stretch{width:100%}
 .clearfix::before,.clearfix::after,.float-group::before,.float-group::after{content:" ";display:table}
 .clearfix::after,.float-group::after{clear:both}
-:not(pre):not([class^=L])>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background:#f7f7f8;-webkit-border-radius:4px;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed;word-wrap:break-word}
-:not(pre)>code.nobreak{word-wrap:normal}
-:not(pre)>code.nowrap{white-space:nowrap}
+:not(pre).nobreak{word-wrap:normal}
+:not(pre).nowrap{white-space:nowrap}
+:not(pre).pre-wrap{white-space:pre-wrap}
+:not(pre):not([class^=L])>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background:#f7f7f8;-webkit-border-radius:4px;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed}
 pre{color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;line-height:1.45;text-rendering:optimizeSpeed}
 pre code,pre pre{color:inherit;font-size:inherit;line-height:inherit}
 pre>code{display:block}
@@ -182,7 +183,7 @@ body.toc2.toc-right{padding-left:0;padding-right:20em}}
 #content #toc{border-style:solid;border-width:1px;border-color:#e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;-webkit-border-radius:4px;border-radius:4px}
 #content #toc>:first-child{margin-top:0}
 #content #toc>:last-child{margin-bottom:0}
-#footer{max-width:100%;background:rgba(0,0,0,.8);padding:1.25em}
+#footer{max-width:none;background:rgba(0,0,0,.8);padding:1.25em}
 #footer-text{color:rgba(255,255,255,.8);line-height:1.44}
 #content{margin-bottom:.625em}
 .sect1{padding-bottom:.625em}
@@ -205,7 +206,7 @@ table.tableblock #preamble>.sectionbody>[class="paragraph"]:first-of-type p{font
 .admonitionblock>table td.icon{text-align:center;width:80px}
 .admonitionblock>table td.icon img{max-width:none}
 .admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
-.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #dddddf;color:rgba(0,0,0,.6)}
+.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #dddddf;color:rgba(0,0,0,.6);word-wrap:anywhere}
 .admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
 .exampleblock>.content{border-style:solid;border-width:1px;border-color:#e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;-webkit-border-radius:4px;border-radius:4px}
 .exampleblock>.content>:first-child{margin-top:0}
@@ -215,7 +216,7 @@ table.tableblock #preamble>.sectionbody>[class="paragraph"]:first-of-type p{font
 .sidebarblock>:last-child{margin-bottom:0}
 .sidebarblock>.content>.title{color:#7a2518;margin-top:0;text-align:center}
 .exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
-.literalblock pre,.listingblock>.content>pre{-webkit-border-radius:4px;border-radius:4px;word-wrap:break-word;overflow-x:auto;padding:1em;font-size:.8125em}
+.literalblock pre,.listingblock>.content>pre{-webkit-border-radius:4px;border-radius:4px;overflow-x:auto;padding:1em;font-size:.8125em}
 @media screen and (min-width:768px){.literalblock pre,.listingblock>.content>pre{font-size:.90625em}}
 @media screen and (min-width:1280px){.literalblock pre,.listingblock>.content>pre{font-size:1em}}
 .literalblock pre,.listingblock>.content>pre:not(.highlight),.listingblock>.content>pre[class="highlight"],.listingblock>.content>pre[class^="highlight "]{background:#f7f7f8}
@@ -261,21 +262,20 @@ pre.pygments .lineno::before{content:"";margin-right:-.125em}
 .quoteblock.excerpt,.quoteblock .quoteblock{margin-left:0}
 .quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{color:inherit;font-size:1.0625rem}
 .quoteblock.excerpt .attribution,.quoteblock .quoteblock .attribution{color:inherit;text-align:left;margin-right:0}
-table.tableblock{max-width:100%;border-collapse:separate}
 p.tableblock:last-child{margin-bottom:0}
+td.tableblock>.content{margin-bottom:1.25em;word-wrap:anywhere}
 td.tableblock>.content>:last-child{margin-bottom:-1.25em}
-td.tableblock>.content>:last-child.sidebarblock{margin-bottom:0}
 table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
-table.grid-all>thead>tr>.tableblock,table.grid-all>tbody>tr>.tableblock{border-width:0 1px 1px 0}
-table.grid-all>tfoot>tr>.tableblock{border-width:1px 1px 0 0}
-table.grid-cols>*>tr>.tableblock{border-width:0 1px 0 0}
-table.grid-rows>thead>tr>.tableblock,table.grid-rows>tbody>tr>.tableblock{border-width:0 0 1px}
-table.grid-rows>tfoot>tr>.tableblock{border-width:1px 0 0}
-table.grid-all>*>tr>.tableblock:last-child,table.grid-cols>*>tr>.tableblock:last-child{border-right-width:0}
-table.grid-all>tbody>tr:last-child>.tableblock,table.grid-all>thead:last-child>tr>.tableblock,table.grid-rows>tbody>tr:last-child>.tableblock,table.grid-rows>thead:last-child>tr>.tableblock{border-bottom-width:0}
+table.grid-all>*>tr>*{border-width:1px}
+table.grid-cols>*>tr>*{border-width:0 1px}
+table.grid-rows>*>tr>*{border-width:1px 0}
 table.frame-all{border-width:1px}
+table.frame-ends{border-width:1px 0}
 table.frame-sides{border-width:0 1px}
-table.frame-topbot,table.frame-ends{border-width:1px 0}
+table.frame-none>colgroup+*>:first-child>*,table.frame-sides>colgroup+*>:first-child>*{border-top-width:0}
+table.frame-none>:last-child>:last-child>*,table.frame-sides>:last-child>:last-child>*{border-bottom-width:0}
+table.frame-none>*>tr>:first-child,table.frame-ends>*>tr>:first-child{border-left-width:0}
+table.frame-none>*>tr>:last-child,table.frame-ends>*>tr>:last-child{border-right-width:0}
 table.stripes-all tr,table.stripes-odd tr:nth-of-type(odd),table.stripes-even tr:nth-of-type(even),table.stripes-hover tr:hover{background:#f8f8f7}
 th.halign-left,td.halign-left{text-align:left}
 th.halign-right,td.halign-right{text-align:right}
@@ -284,7 +284,7 @@ th.valign-top,td.valign-top{vertical-align:top}
 th.valign-bottom,td.valign-bottom{vertical-align:bottom}
 th.valign-middle,td.valign-middle{vertical-align:middle}
 table thead th,table tfoot th{font-weight:bold}
-tbody tr th{display:table-cell;line-height:1.6;background:#f7f8f7}
+tbody tr th{background:#f7f8f7}
 tbody tr th,tbody tr th p,tfoot tr th,tfoot tr th p{color:rgba(0,0,0,.8);font-weight:bold}
 p.tableblock>code:only-child{background:none;padding:0}
 p.tableblock{font-size:1em}
@@ -313,6 +313,7 @@ ol.lowergreek{list-style-type:lower-greek}
 .hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
 td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
 td.hdlist1{font-weight:bold;padding-bottom:1.25em}
+td.hdlist2{word-wrap:anywhere}
 .literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
 .colist td:not([class]):first-child{padding:.4em .75em 0;line-height:1;vertical-align:top}
 .colist td:not([class]):first-child img{max-width:none}
@@ -385,7 +386,7 @@ a span.icon>.fa{cursor:inherit}
 .admonitionblock td.icon .icon-warning::before{content:"\f071";color:#bf6900}
 .admonitionblock td.icon .icon-caution::before{content:"\f06d";color:#bf3400}
 .admonitionblock td.icon .icon-important::before{content:"\f06a";color:#bf0000}
-.conum[data-value]{display:inline-block;color:#fff!important;background:rgba(0,0,0,.8);-webkit-border-radius:100px;border-radius:100px;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
+.conum[data-value]{display:inline-block;color:#fff!important;background:rgba(0,0,0,.8);-webkit-border-radius:50%;border-radius:50%;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
 .conum[data-value] *{color:#fff!important}
 .conum[data-value]+b{display:none}
 .conum[data-value]::after{content:attr(data-value)}
@@ -412,6 +413,7 @@ thead{display:table-header-group}
 svg{max-width:100%}
 p,blockquote,dt,td.content{font-size:1em;orphans:3;widows:3}
 h2,h3,#toctitle,.sidebarblock>.content>.title{page-break-after:avoid}
+#header,#content,#footnotes,#footer{max-width:none}
 #toc,.sidebarblock,.exampleblock>.content{background:none!important}
 #toc{border-bottom:1px solid #dddddf!important;padding-bottom:0!important}
 body.book #header{text-align:center}

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 2.0.10">
+<meta name="generator" content="Asciidoctor 2.0.12">
 <title>i3blocks</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
@@ -47,7 +47,7 @@ textarea{overflow:auto;vertical-align:top}
 table{border-collapse:collapse;border-spacing:0}
 *,*::before,*::after{-moz-box-sizing:border-box;-webkit-box-sizing:border-box;box-sizing:border-box}
 html,body{font-size:100%}
-body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;font-weight:400;font-style:normal;line-height:1;position:relative;cursor:auto;tab-size:4;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
+body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;font-weight:400;font-style:normal;line-height:1;position:relative;cursor:auto;tab-size:4;word-wrap:anywhere;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
 a:hover{cursor:pointer}
 img,object,embed{max-width:100%;height:auto}
 object,embed{height:100%}
@@ -62,10 +62,8 @@ img{-ms-interpolation-mode:bicubic}
 img,object,svg{display:inline-block;vertical-align:middle}
 textarea{height:auto;min-height:50px}
 select{width:100%}
-.center{margin-left:auto;margin-right:auto}
-.stretch{width:100%}
 .subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#7a2518;font-weight:400;margin-top:0;margin-bottom:.25em}
-div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0;direction:ltr}
+div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0}
 a{color:#2156a5;text-decoration:underline;line-height:inherit}
 a:hover,a:focus{color:#1d4b8f}
 a img{border:0}
@@ -105,19 +103,22 @@ h1{font-size:2.75em}
 h2{font-size:2.3125em}
 h3,#toctitle,.sidebarblock>.content>.title{font-size:1.6875em}
 h4{font-size:1.4375em}}
-table{background:#fff;margin-bottom:1.25em;border:solid 1px #dedede}
+table{background:#fff;margin-bottom:1.25em;border:solid 1px #dedede;word-wrap:normal}
 table thead,table tfoot{background:#f7f8f7}
 table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
 table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
 table tr.even,table tr.alt{background:#f8f8f7}
-table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{display:table-cell;line-height:1.6}
+table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{line-height:1.6}
 h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
 h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
+.center{margin-left:auto;margin-right:auto}
+.stretch{width:100%}
 .clearfix::before,.clearfix::after,.float-group::before,.float-group::after{content:" ";display:table}
 .clearfix::after,.float-group::after{clear:both}
-:not(pre):not([class^=L])>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background:#f7f7f8;-webkit-border-radius:4px;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed;word-wrap:break-word}
-:not(pre)>code.nobreak{word-wrap:normal}
-:not(pre)>code.nowrap{white-space:nowrap}
+:not(pre).nobreak{word-wrap:normal}
+:not(pre).nowrap{white-space:nowrap}
+:not(pre).pre-wrap{white-space:pre-wrap}
+:not(pre):not([class^=L])>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background:#f7f7f8;-webkit-border-radius:4px;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed}
 pre{color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;line-height:1.45;text-rendering:optimizeSpeed}
 pre code,pre pre{color:inherit;font-size:inherit;line-height:inherit}
 pre>code{display:block}
@@ -182,7 +183,7 @@ body.toc2.toc-right{padding-left:0;padding-right:20em}}
 #content #toc{border-style:solid;border-width:1px;border-color:#e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;-webkit-border-radius:4px;border-radius:4px}
 #content #toc>:first-child{margin-top:0}
 #content #toc>:last-child{margin-bottom:0}
-#footer{max-width:100%;background:rgba(0,0,0,.8);padding:1.25em}
+#footer{max-width:none;background:rgba(0,0,0,.8);padding:1.25em}
 #footer-text{color:rgba(255,255,255,.8);line-height:1.44}
 #content{margin-bottom:.625em}
 .sect1{padding-bottom:.625em}
@@ -205,7 +206,7 @@ table.tableblock #preamble>.sectionbody>[class="paragraph"]:first-of-type p{font
 .admonitionblock>table td.icon{text-align:center;width:80px}
 .admonitionblock>table td.icon img{max-width:none}
 .admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
-.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #dddddf;color:rgba(0,0,0,.6)}
+.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #dddddf;color:rgba(0,0,0,.6);word-wrap:anywhere}
 .admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
 .exampleblock>.content{border-style:solid;border-width:1px;border-color:#e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;-webkit-border-radius:4px;border-radius:4px}
 .exampleblock>.content>:first-child{margin-top:0}
@@ -215,7 +216,7 @@ table.tableblock #preamble>.sectionbody>[class="paragraph"]:first-of-type p{font
 .sidebarblock>:last-child{margin-bottom:0}
 .sidebarblock>.content>.title{color:#7a2518;margin-top:0;text-align:center}
 .exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
-.literalblock pre,.listingblock>.content>pre{-webkit-border-radius:4px;border-radius:4px;word-wrap:break-word;overflow-x:auto;padding:1em;font-size:.8125em}
+.literalblock pre,.listingblock>.content>pre{-webkit-border-radius:4px;border-radius:4px;overflow-x:auto;padding:1em;font-size:.8125em}
 @media screen and (min-width:768px){.literalblock pre,.listingblock>.content>pre{font-size:.90625em}}
 @media screen and (min-width:1280px){.literalblock pre,.listingblock>.content>pre{font-size:1em}}
 .literalblock pre,.listingblock>.content>pre:not(.highlight),.listingblock>.content>pre[class="highlight"],.listingblock>.content>pre[class^="highlight "]{background:#f7f7f8}
@@ -261,21 +262,20 @@ pre.pygments .lineno::before{content:"";margin-right:-.125em}
 .quoteblock.excerpt,.quoteblock .quoteblock{margin-left:0}
 .quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{color:inherit;font-size:1.0625rem}
 .quoteblock.excerpt .attribution,.quoteblock .quoteblock .attribution{color:inherit;text-align:left;margin-right:0}
-table.tableblock{max-width:100%;border-collapse:separate}
 p.tableblock:last-child{margin-bottom:0}
+td.tableblock>.content{margin-bottom:1.25em;word-wrap:anywhere}
 td.tableblock>.content>:last-child{margin-bottom:-1.25em}
-td.tableblock>.content>:last-child.sidebarblock{margin-bottom:0}
 table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
-table.grid-all>thead>tr>.tableblock,table.grid-all>tbody>tr>.tableblock{border-width:0 1px 1px 0}
-table.grid-all>tfoot>tr>.tableblock{border-width:1px 1px 0 0}
-table.grid-cols>*>tr>.tableblock{border-width:0 1px 0 0}
-table.grid-rows>thead>tr>.tableblock,table.grid-rows>tbody>tr>.tableblock{border-width:0 0 1px}
-table.grid-rows>tfoot>tr>.tableblock{border-width:1px 0 0}
-table.grid-all>*>tr>.tableblock:last-child,table.grid-cols>*>tr>.tableblock:last-child{border-right-width:0}
-table.grid-all>tbody>tr:last-child>.tableblock,table.grid-all>thead:last-child>tr>.tableblock,table.grid-rows>tbody>tr:last-child>.tableblock,table.grid-rows>thead:last-child>tr>.tableblock{border-bottom-width:0}
+table.grid-all>*>tr>*{border-width:1px}
+table.grid-cols>*>tr>*{border-width:0 1px}
+table.grid-rows>*>tr>*{border-width:1px 0}
 table.frame-all{border-width:1px}
+table.frame-ends{border-width:1px 0}
 table.frame-sides{border-width:0 1px}
-table.frame-topbot,table.frame-ends{border-width:1px 0}
+table.frame-none>colgroup+*>:first-child>*,table.frame-sides>colgroup+*>:first-child>*{border-top-width:0}
+table.frame-none>:last-child>:last-child>*,table.frame-sides>:last-child>:last-child>*{border-bottom-width:0}
+table.frame-none>*>tr>:first-child,table.frame-ends>*>tr>:first-child{border-left-width:0}
+table.frame-none>*>tr>:last-child,table.frame-ends>*>tr>:last-child{border-right-width:0}
 table.stripes-all tr,table.stripes-odd tr:nth-of-type(odd),table.stripes-even tr:nth-of-type(even),table.stripes-hover tr:hover{background:#f8f8f7}
 th.halign-left,td.halign-left{text-align:left}
 th.halign-right,td.halign-right{text-align:right}
@@ -284,7 +284,7 @@ th.valign-top,td.valign-top{vertical-align:top}
 th.valign-bottom,td.valign-bottom{vertical-align:bottom}
 th.valign-middle,td.valign-middle{vertical-align:middle}
 table thead th,table tfoot th{font-weight:bold}
-tbody tr th{display:table-cell;line-height:1.6;background:#f7f8f7}
+tbody tr th{background:#f7f8f7}
 tbody tr th,tbody tr th p,tfoot tr th,tfoot tr th p{color:rgba(0,0,0,.8);font-weight:bold}
 p.tableblock>code:only-child{background:none;padding:0}
 p.tableblock{font-size:1em}
@@ -313,6 +313,7 @@ ol.lowergreek{list-style-type:lower-greek}
 .hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
 td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
 td.hdlist1{font-weight:bold;padding-bottom:1.25em}
+td.hdlist2{word-wrap:anywhere}
 .literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
 .colist td:not([class]):first-child{padding:.4em .75em 0;line-height:1;vertical-align:top}
 .colist td:not([class]):first-child img{max-width:none}
@@ -385,7 +386,7 @@ a span.icon>.fa{cursor:inherit}
 .admonitionblock td.icon .icon-warning::before{content:"\f071";color:#bf6900}
 .admonitionblock td.icon .icon-caution::before{content:"\f06d";color:#bf3400}
 .admonitionblock td.icon .icon-important::before{content:"\f06a";color:#bf0000}
-.conum[data-value]{display:inline-block;color:#fff!important;background:rgba(0,0,0,.8);-webkit-border-radius:100px;border-radius:100px;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
+.conum[data-value]{display:inline-block;color:#fff!important;background:rgba(0,0,0,.8);-webkit-border-radius:50%;border-radius:50%;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
 .conum[data-value] *{color:#fff!important}
 .conum[data-value]+b{display:none}
 .conum[data-value]::after{content:attr(data-value)}
@@ -412,6 +413,7 @@ thead{display:table-header-group}
 svg{max-width:100%}
 p,blockquote,dt,td.content{font-size:1em;orphans:3;widows:3}
 h2,h3,#toctitle,.sidebarblock>.content>.title{page-break-after:avoid}
+#header,#content,#footnotes,#footer{max-width:none}
 #toc,.sidebarblock,.exampleblock>.content{background:none!important}
 #toc{border-bottom:1px solid #dddddf!important;padding-bottom:0!important}
 body.book #header{text-align:center}
@@ -443,7 +445,11 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div id="toctitle">Table of Contents</div>
 <ul class="sectlevel1">
 <li><a href="#_example">Example</a></li>
-<li><a href="#_installation">Installation</a></li>
+<li><a href="#_installation">Installation</a>
+<ul class="sectlevel2">
+<li><a href="#_dependencies">Dependencies</a></li>
+</ul>
+</li>
 <li><a href="#_getting_started">Getting started</a></li>
 <li><a href="#_blocks">Blocks</a></li>
 <li><a href="#_i3bar_properties">i3bar properties</a></li>
@@ -453,6 +459,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_interval">interval</a></li>
 <li><a href="#_signal">signal</a></li>
 <li><a href="#_format">format</a></li>
+<li><a href="#_ticker">ticker</a></li>
 </ul>
 </li>
 <li><a href="#_click">Click</a></li>
@@ -550,6 +557,17 @@ cd i3blocks
 ./configure
 make
 make install</code></pre>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_dependencies">Dependencies</h3>
+<div class="paragraph">
+<p>Since ticker feature has been introduced, there is only one package (<a href="https://github.com/JuliaStrings/utf8proc">libutf8proc</a>) which is need to be installed. On Debian-based systems it can be obtained via apt:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>sudo apt-get install libutf8proc-dev</code></pre>
+</div>
 </div>
 </div>
 </div>
@@ -909,6 +927,52 @@ _count=0
 command=printf '{"full_text":"Counter: %s", "_count":%d}\n' $_count $((_count + 1))
 format=json
 interval=1</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_ticker">ticker</h3>
+<div class="paragraph">
+<p>Optional property. Enable or disable ticker feature. Valid values are <code>true</code> &amp; <code>false</code>.
+This feature only works with the raw format. It will scroll output string char by char with given interval. Offset zeroes if there are changes in the output string.
+Default value is <code>false</code>.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-ini" data-lang="ini">#Output string differs every minute
+[ticker_test]
+command=echo 'TEST_STRING-'$(date +%M)
+interval=1
+ticker=true
+ticker_interval=2</code></pre>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_ticker_delimeter">ticker_delimeter</h4>
+<div class="paragraph">
+<p>Optional property (use in conjunction with <em>ticker</em>). Delimeter character which separates beginning &amp; ending of the output string. If value is set to a string containing multiple characters, only the first character will be used as the delimeter.
+Default value is <code>|</code>.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_ticker_direction">ticker_direction</h4>
+<div class="paragraph">
+<p>Direction of the ticker. Valid values are <code>right</code> (shortcut <code>r</code>) &amp; <code>left</code> (shortcut <code>l</code>).
+Default value is <code>left</code>.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_ticker_chars_limit">ticker_chars_limit</h4>
+<div class="paragraph">
+<p>Limit of the characters to be displayed if <em>ticker</em> is enabled. <code>0</code> or negative values set limit to default value.
+Default value is <code>16</code>.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_ticker_interval">ticker_interval</h4>
+<div class="paragraph">
+<p>Optional property. Defines interval of time after which the output string is shifted by a single char.
+Default value is <code>1</code>.</p>
 </div>
 </div>
 </div>

--- a/ticker.c
+++ b/ticker.c
@@ -1,0 +1,250 @@
+/*
+ * ticker.c - ticker implementation
+ * Copyright (C) 2022 Bogdan Migunov
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <utf8proc.h>
+
+#include "ticker.h"
+#include "log.h"
+#include "sys.h"
+
+static enum ticker_result ticker_scroll(struct ticker *, char *);
+static enum ticker_result ticker_convert_utf8_to_mbs(utf8proc_int32_t *, char *,
+		unsigned int);
+
+struct ticker *ticker_create(void)
+{
+	struct ticker *new_ticker = calloc(1, sizeof(struct ticker));
+	int err;
+
+	new_ticker->delimeter = TICKER_DELIMETER_DEFAULT;
+	new_ticker->direction = TICKER_DIRECTION_DEFAULT;
+	new_ticker->chars_limit = TICKER_CHARS_LIMIT_DEFAULT;
+	new_ticker->interval = TICKER_INTERVAL_DEFAULT;
+
+	err = sys_gettime(&(new_ticker->timestamp));
+	if (err) {
+		error("sys_gettime() error, code: %d", err);
+		free(new_ticker);
+
+		return NULL;
+	}
+
+	new_ticker->full_text_saved = NULL;
+	new_ticker->label_saved = NULL;
+
+	memset(new_ticker->buf, '\0', sizeof(char) * BUFSIZ);
+	memset(new_ticker->utf8_buf, '\0', sizeof(utf8proc_int32_t) * UTF8_BUFSIZ);
+	new_ticker->utf8_buf_strlen = 0;
+	new_ticker->offset = 0;
+
+	return new_ticker;
+};
+
+void ticker_destroy(struct ticker *ticker)
+{
+	debug("ticker_destroy()");
+	free(ticker->full_text_saved);
+	free(ticker->label_saved);
+	free(ticker);
+
+	return;
+};
+
+char *ticker_output_get(struct ticker *ticker, const char *full_text)
+{
+	char *ticker_output = calloc((ticker->chars_limit + 1) * sizeof(utf8proc_int32_t),
+			sizeof(char));
+
+	if (strcmp(ticker->buf, full_text) != 0) {
+		debug("New string");
+		ticker->offset = 0;
+
+		memset(ticker->buf, '\0', BUFSIZ * sizeof(char));
+		memset(ticker->utf8_buf, '\0', sizeof(utf8proc_int32_t) * UTF8_BUFSIZ);
+
+		snprintf(ticker->buf, sizeof(ticker->buf), "%s", full_text);
+		ticker->utf8_buf_strlen =
+			utf8proc_decompose((const utf8proc_uint8_t *)ticker->buf, 0,
+					ticker->utf8_buf, UTF8_BUFSIZ, UTF8PROC_NULLTERM);
+		if (ticker->utf8_buf_strlen < 0) {
+			error("Failed to decompose UTF8 multibyte string into an array of codepoints; error code: %d",
+					ticker->utf8_buf_strlen);
+			memset(ticker->buf, '\0', sizeof(char) * BUFSIZ);
+			memset(ticker->utf8_buf, '\0',
+					sizeof(utf8proc_int32_t) * UTF8_BUFSIZ);
+			free(ticker_output);
+
+			return NULL;
+		}
+		debug("utf8_buf_strlen: %d", ticker->utf8_buf_strlen);
+
+		*(ticker->utf8_buf + ticker->utf8_buf_strlen) = ' ';
+		*(ticker->utf8_buf + ticker->utf8_buf_strlen + 1) = ticker->delimeter;
+		*(ticker->utf8_buf + ticker->utf8_buf_strlen + 2) = ' ';
+	}
+
+	if (ticker->utf8_buf_strlen <= ticker->chars_limit) {
+		debug("utf8_buf_strlen (%d) is less than chars_limit (%d)",
+				ticker->utf8_buf_strlen, ticker->chars_limit);
+		snprintf(ticker_output, BUFSIZ, "%s", full_text);
+
+		return ticker_output;
+	}
+
+	if (ticker_scroll(ticker, ticker_output) != TICKER_RESULT_SUCCESS) {
+		error("Failed to scroll string");
+		memset(ticker->buf, '\0', sizeof(char) * BUFSIZ);
+		memset(ticker->utf8_buf, '\0', sizeof(utf8proc_int32_t) * UTF8_BUFSIZ);
+		free(ticker_output);
+		return NULL;
+	}
+	else {
+		debug("ticker_output: %s", ticker_output);
+
+		return ticker_output;
+	}
+};
+
+enum ticker_result ticker_delimeter_set(struct ticker *ticker,
+		const char *delimeter)
+{
+	utf8proc_int32_t utf8_delimeter_str[UTF8_BUFSIZ];
+	utf8proc_ssize_t utf8_delimeter_strlen = 0;
+
+	memset(utf8_delimeter_str, '\0', sizeof(utf8proc_int32_t) * UTF8_BUFSIZ);
+	utf8_delimeter_strlen =
+		utf8proc_decompose((const utf8proc_uint8_t *)delimeter, 0,
+				utf8_delimeter_str, UTF8_BUFSIZ, UTF8PROC_NULLTERM);
+
+	if (utf8_delimeter_strlen <= 0) {
+		if (utf8_delimeter_strlen != 0)
+			error("Failed to decompose UTF8 multibyte string; error code: %d",
+					utf8_delimeter_strlen);
+		else
+			error("Empty delimeter string");
+
+		return TICKER_RESULT_ERR;
+	}
+
+	ticker->delimeter = utf8_delimeter_str[0];
+
+	return TICKER_RESULT_SUCCESS;
+};
+
+static enum ticker_result ticker_scroll(struct ticker *ticker,
+		char *ticker_output)
+{
+	utf8proc_int32_t utf8_output[UTF8_BUFSIZ];
+
+	memset(utf8_output, '\0', UTF8_BUFSIZ * sizeof(utf8proc_int32_t));
+	debug("offset: %d", ticker->offset);
+
+	if (ticker->direction == TICKER_DIRECTION_LEFT)
+		if (ticker->offset <= (ticker->utf8_buf_strlen + 3) -
+				ticker->chars_limit)
+			memcpy(utf8_output, ticker->utf8_buf + ticker->offset,
+					ticker->chars_limit * sizeof(utf8proc_int32_t));
+		else {
+			memcpy(utf8_output,
+					ticker->utf8_buf + ticker->offset,
+					sizeof(utf8proc_int32_t) * ((ticker->utf8_buf_strlen + 3) -
+						ticker->offset));
+			memcpy(utf8_output + ((ticker->utf8_buf_strlen + 3) -
+						ticker->offset),
+					ticker->utf8_buf,
+					sizeof(utf8proc_int32_t) * (ticker->chars_limit -
+						((ticker->utf8_buf_strlen + 3) - ticker->offset)));
+		}
+	else
+		if (ticker->direction == TICKER_DIRECTION_RIGHT) {
+			if (ticker->offset < ticker->chars_limit) {
+				memcpy(utf8_output,
+						ticker->utf8_buf + (ticker->utf8_buf_strlen + 3) -
+						ticker->offset,
+						ticker->offset * sizeof(utf8proc_int32_t));
+				memcpy(utf8_output + ticker->offset,
+						ticker->utf8_buf,
+						(ticker->chars_limit - ticker->offset) *
+						sizeof(utf8proc_int32_t));
+			}
+			else
+				memcpy(utf8_output,
+						ticker->utf8_buf + (ticker->utf8_buf_strlen + 3) -
+						ticker->offset,
+						ticker->chars_limit * sizeof(utf8proc_int32_t));
+		}
+
+	if (ticker->interval > 0) {
+		int err;
+		unsigned long now;
+		const unsigned long next_update = ticker->timestamp + ticker->interval;
+
+		err = sys_gettime(&now);
+		if (err) {
+			error("sys_gettime() error; code: %d", err);
+
+			return TICKER_RESULT_ERR;
+		}
+
+		if (((long) (next_update - now)) <= 0) {
+			debug("ticker expired: incrementing offset");
+
+			if (ticker->timestamp == now) {
+				debug("looping too fast");
+
+				return TICKER_RESULT_ERR;
+			}
+
+			if (ticker->offset >= ticker->utf8_buf_strlen + 2) {
+				debug("Resetting offset");
+				ticker->offset = 0;
+			}
+			else
+				++(ticker->offset);
+
+			ticker->timestamp = now;
+		}
+	}
+
+	return ticker_convert_utf8_to_mbs(utf8_output, ticker_output,
+			ticker->chars_limit);
+};
+
+static enum ticker_result ticker_convert_utf8_to_mbs(utf8proc_int32_t *utf8_str,
+		char *mbs, unsigned int n)
+{
+	utf8proc_uint8_t utf8_codepoint[sizeof(utf8proc_int32_t)];
+
+	for (unsigned int i = 0; i < n; ++i) {
+		memset(utf8_codepoint, '\0',
+				sizeof(utf8proc_int32_t) * sizeof(utf8proc_uint8_t));
+
+		if (utf8proc_encode_char(*(utf8_str + i), utf8_codepoint))
+			strncat(mbs, (const char *)utf8_codepoint,
+					sizeof(utf8proc_int32_t));
+		else {
+			error("Failed to encode char %X", *(utf8_str + i));
+
+			return TICKER_RESULT_ERR;
+		}
+	}
+
+	return TICKER_RESULT_SUCCESS;
+};

--- a/ticker.c
+++ b/ticker.c
@@ -1,6 +1,6 @@
 /*
  * ticker.c - ticker implementation
- * Copyright (C) 2022 Bogdan Migunov
+ * Copyright (C) 2022-2023 Bogdan Migunov
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/ticker.h
+++ b/ticker.h
@@ -1,6 +1,6 @@
 /*
  * ticker.h - definition of a ticker
- * Copyright (C) 2022 Bogdan Migunov
+ * Copyright (C) 2022-2023 Bogdan Migunov
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/ticker.h
+++ b/ticker.h
@@ -1,0 +1,67 @@
+/*
+ * ticker.h - definition of a ticker
+ * Copyright (C) 2022 Bogdan Migunov
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef TICKER_H
+#define TICKER_H
+
+#include <stdio.h>
+#include <utf8proc.h>
+
+#define TICKER_CONFIG_OPTION             "ticker"
+#define TICKER_CONFIG_OPTION_DELIMETER   "ticker_delimeter"
+#define TICKER_CONFIG_OPTION_DIRECTION   "ticker_direction"
+#define TICKER_CONFIG_OPTION_CHARS_LIMIT "ticker_chars_limit"
+#define TICKER_CONFIG_OPTION_INTERVAL    "ticker_interval"
+
+#define TICKER_DELIMETER_DEFAULT   '|'
+#define TICKER_CHARS_LIMIT_DEFAULT 16
+#define TICKER_INTERVAL_DEFAULT    1
+
+#define TICKER_DIRECTION_LEFT    0
+#define TICKER_DIRECTION_RIGHT   1
+#define TICKER_DIRECTION_DEFAULT TICKER_DIRECTION_LEFT
+
+#define UTF8_BUFSIZ ( BUFSIZ / sizeof(utf8proc_int32_t) )
+
+struct ticker {
+	utf8proc_int32_t delimeter;
+	unsigned char    direction;
+	unsigned int     chars_limit;
+
+	unsigned int     interval;
+	unsigned long    timestamp;
+	char             *full_text_saved;
+	char             *label_saved;
+
+	char             buf[BUFSIZ];
+	utf8proc_int32_t utf8_buf[UTF8_BUFSIZ];
+	utf8proc_ssize_t utf8_buf_strlen;
+	unsigned int     offset;
+};
+
+enum ticker_result {
+	TICKER_RESULT_SUCCESS = 0,
+	TICKER_RESULT_ERR,
+};
+
+struct ticker *ticker_create(void);
+void ticker_destroy(struct ticker *);
+char *ticker_output_get(struct ticker *, const char *);
+enum ticker_result ticker_delimeter_set(struct ticker *, const char *);
+
+#endif /* TICKER_H */


### PR DESCRIPTION
Ticker feature implementation.
Added new options, such as: "ticker", "ticker_delimeter", "ticker_interval", "ticker_chars_limit" & "ticker_direction".

"ticker" option enables/disables feature for a given block. "ticker_delimeter" sets a character to separate tail and head of the output string.
"ticker_interval" determines the amount of time periods on which the output string is being shifted.
"ticker_chars_limit" defines the amount of symbols to be displayed. "ticker_direction" defines the direction in which the characters will shift.

This feature required to add a library to work with UTF8 characters, so now i3blocks has "libutf8proc" in its dependencies.

Closes #466