### PR TITLE
Install i3blocks on Fedora without COPR

### DIFF
--- a/docs/README.adoc
+++ b/docs/README.adoc
@@ -50,7 +50,7 @@ interval=5
 * Gentoo: link:https://packages.gentoo.org/packages/x11-misc/i3blocks[x11-misc/i3blocks]
 * Debian: link:https://packages.debian.org/i3blocks[i3blocks]
 * Ubuntu: link:http://packages.ubuntu.com/i3blocks[i3blocks]
-* Fedora (COPR): link:https://copr.fedorainfracloud.org/coprs/wyvie/i3blocks[i3blocks]
+* Fedora: link:https://packages.fedoraproject.org/pkgs/i3blocks/i3blocks/[i3blocks]
 * Void Linux: link:https://github.com/void-linux/void-packages/tree/master/srcpkgs/i3blocks[i3blocks]
 
 Or can be installed from source with:


### PR DESCRIPTION
`i3blocks` is part of the official Fedora repositories; COPR is no longer required.

To verify:

* `podman run --rm -it fedora:38`
* `dnf install i3blocks`
* Optional: `dnf info i3blocks`